### PR TITLE
docs: Use light theme from localStorage

### DIFF
--- a/documentation/src/components/structure/BaseLayout.astro
+++ b/documentation/src/components/structure/BaseLayout.astro
@@ -24,6 +24,7 @@ interface Props {
 			if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
 				const storedTheme = localStorage.getItem("theme");
 				if (storedTheme === "dark") return "dark";
+				if (storedTheme === "light") return "light";
 			}
 			if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
 				return "dark";


### PR DESCRIPTION
Currently, if the user's preferred color scheme is dark and they switch the theme to light, light mode does not persist when reloading the page or when navigating to another link and the page will switch to dark mode.
This change will use the theme from localStorage regardless of the user's preferred color scheme.