### PR TITLE
`@lucia-auth/sveltekit`: v0.1.4

### DIFF
--- a/documentation/src/pages/sveltekit/api-reference/client-api.md
+++ b/documentation/src/pages/sveltekit/api-reference/client-api.md
@@ -35,17 +35,29 @@ const userId = user?.userId;
 
 ## `handleSession()`
 
-Handles sessions in the client - must be called on the root layout for all client and load methods to work. This will sync the global client state with the server's and listen for session state change across tabs.
+Handles sessions in the client - must be called on the root layout for all client and load methods to work. This will listen for session updates across tabs. The provided callback will be called whenever a session changes in a different tab.
 
 ```ts
-const handleSession: (pageStore: Page) => void;
+const handleSession: (pageStore: Page, onSessionUpdate?: () => void) => void;
 ```
 
 #### Parameter
 
-| name      | type                                                          | description |
-| --------- | ------------------------------------------------------------- | ----------- |
-| pageStore | [`Page`](https://kit.svelte.dev/docs/types#sveltejs-kit-page) | Page store  |
+| name            | type                                                          | description                                               | optional |
+| --------------- | ------------------------------------------------------------- | --------------------------------------------------------- | -------- |
+| pageStore       | [`Page`](https://kit.svelte.dev/docs/types#sveltejs-kit-page) | Page store                                                |          |
+| onSessionUpdate | `Function`                                                    | A callback function that will be called on session update | true     |
+
+#### Example
+
+```ts
+import { page } from "$app/stores";
+import { handleSession } from "@lucia-auth/sveltekit/client";
+
+handleSession(page, () => {
+	alert("Your session has been updated - please refresh the page");
+});
+```
 
 ## `signOut()`
 

--- a/packages/sveltekit/CHANGELOG.md
+++ b/packages/sveltekit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.1.4
+
+- [Breaking] `handleSession()` no longer sync sessions across tabs
+- `handleSession()` can take an optional callback that will be called on session change 
+
 ## 0.1.3
 
 - Resolve issue where `handleSession()` was throwing error on pages without `getUser()` in the load function [#182](https://github.com/pilcrowOnPaper/lucia-auth/issues/182#issuecomment-1296033717)

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/sveltekit",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Lucia integration for SvelteKit",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -45,6 +45,7 @@
 		}
 	},
 	"devDependencies": {
+		"@types/node": "^18.6.2",
 		"lucia-auth": "workspace:*",
 		"svelte": "^3.52.0"
 	}

--- a/packages/sveltekit/src/client/page-data.ts
+++ b/packages/sveltekit/src/client/page-data.ts
@@ -1,0 +1,22 @@
+import type { GlobalWindow, LuciaContext, PageData } from "../types.js";
+
+export const getInitialClientLuciaContext = (): LuciaContext => {
+	const globalWindow = window as GlobalWindow;
+	if (!globalWindow._luciaPageData)
+		throw new Error("_luciaPageData is undefined", {
+			cause: "Make sure auth.handleHooks() is set up inside the hooks.server.ts"
+		});
+	/* 
+    global variable _lucia_page_data is set in index.html rendered by SvelteKit
+    the code that sets the variable is injected by hooks handle function on creating a response.
+    dataArr holds the data returned by server load functions, 
+    which is used for reading cookies and exposing the user to page data in lucia
+    */
+	const dataArr = globalWindow._luciaPageData || [];
+	const pageData = dataArr.reduce((prev, curr) => {
+		if (curr) return { ...prev, ...curr.data };
+		return prev;
+	}, {}) as PageData;
+	if (!pageData._lucia) throw new Error("pageData._lucia is undefined");
+	return pageData._lucia;
+};

--- a/packages/sveltekit/src/client/user.ts
+++ b/packages/sveltekit/src/client/user.ts
@@ -1,0 +1,28 @@
+import type { User } from "lucia-auth";
+import { getContext } from "svelte";
+import { derived, get, type Readable } from "svelte/store";
+import type { GlobalWindow, PageData } from "../types.js";
+
+export type ClientUser = Readonly<User> | null;
+
+export const getServerUser = (): Readable<ClientUser> => {
+	const { page } = getContext("__svelte__") as {
+		page: Readable<{
+			data: PageData;
+		}>;
+	};
+	const luciaContext = get(page).data._lucia
+    if (!luciaContext) throw new Error()
+	return {
+		subscribe: (subscriber) => {
+			subscriber(luciaContext.user);
+			return () => {};
+		}
+	};
+};
+
+export const getClientUser = (): Readable<ClientUser> => {
+	const globalWindow = window as GlobalWindow;
+	if (!globalWindow._luciaStore) throw new Error("");
+	return derived(globalWindow._luciaStore, (val) => val.user);
+};

--- a/packages/sveltekit/src/load/user.ts
+++ b/packages/sveltekit/src/load/user.ts
@@ -24,8 +24,6 @@ export const getUser = async (event: {
 		if (!pageData._lucia) throw new Error("pageData._lucia is undefined");
 		if (!globalWindow._setLuciaStore) throw new Error("_setLuciaStore is undefined");
 		const luciaContext = pageData._lucia;
-		console.log("load")
-		console.log(storedLuciaContext, luciaContext)
 		if (storedLuciaContext.sessionChecksum !== luciaContext.sessionChecksum) {
 			globalWindow._setLuciaStore(luciaContext);
 		}

--- a/packages/sveltekit/src/load/user.ts
+++ b/packages/sveltekit/src/load/user.ts
@@ -1,54 +1,36 @@
 import type { User } from "lucia-auth";
 import { get, readable } from "svelte/store";
-import type { GlobalWindow } from "../types.js";
+import { getInitialClientLuciaContext } from "../client/page-data.js";
+import type { GlobalWindow, LuciaContext, PageData } from "../types.js";
 
 export const getUser = async (event: {
 	parent: () => Promise<any>;
 }): Promise<Readonly<User> | null> => {
 	if (typeof window === "undefined") {
 		// server
-		const data = (await event.parent()) as {
-			_lucia: User | null;
-		};
-		return data._lucia ? Object.freeze(data._lucia) : null;
+		const pageData = (await event.parent()) as PageData;
+		if (!pageData._lucia) throw new Error("pageData._lucia is undefined");
+		return Object.freeze(pageData._lucia.user);
 	}
 	// client
 	const globalWindow = window as GlobalWindow;
-	if (!globalWindow._userStore) {
-		globalWindow._userStore = readable(getInitialClientUser(), (set) => {
-			globalWindow._setUserStore = set
-		})
+	if (globalWindow._luciaHooksRanLast === undefined)
+		throw new Error("pageData._luciaHooksRanLast is undefined");
+	if (globalWindow._luciaHooksRanLast === false) {
+		if (!globalWindow._luciaStore) throw new Error("_luciaStore is undefined");
+		const storedLuciaContext = get(globalWindow._luciaStore);
+		if (storedLuciaContext.user) return storedLuciaContext.user;
+		const pageData = (await event.parent()) as PageData;
+		if (!pageData._lucia) throw new Error("pageData._lucia is undefined");
+		if (!globalWindow._setLuciaStore) throw new Error("_setLuciaStore is undefined");
+		const luciaContext = pageData._lucia;
+		console.log("load")
+		console.log(storedLuciaContext, luciaContext)
+		if (storedLuciaContext.sessionChecksum !== luciaContext.sessionChecksum) {
+			globalWindow._setLuciaStore(luciaContext);
+		}
+		return pageData._lucia.user;
 	}
-	const storedUser = get(globalWindow._userStore);
-	// if hooks ran after before new session set
-	if (storedUser) return storedUser;
-	const data = (await event.parent()) as {
-		_lucia: User | null;
-	};
-	if (!data._lucia) return null;
-	if (!globalWindow._setUserStore) throw new Error("_setUserStore() is undefined");
-	globalWindow._setUserStore(data._lucia);
-	return data._lucia;
-};
-
-const getInitialClientUser = (): User | null => {
-	const globalWindow = window as GlobalWindow;
-	if (!globalWindow._luciaPageData)
-		throw new Error("_luciaPageData is undefined", {
-			cause: "Make sure auth.handleHooks() is set up inside the hooks.server.ts"
-		});
-	/* 
-    global variable _lucia_page_data is set in index.html rendered by SvelteKit
-    the code that sets the variable is injected by hooks handle function on creating a response.
-    dataArr holds the data returned by server load functions, 
-    which is used for reading cookies and exposing the user to page data in lucia
-    */
-	const dataArr = globalWindow._luciaPageData || [];
-	const pageData = dataArr.reduce((prev, curr) => {
-		if (curr) return { ...prev, ...curr.data };
-		return prev;
-	}, {}) as {
-		_lucia?: User | null;
-	};
-	return pageData._lucia || null;
+	const initialLuciaContext = getInitialClientLuciaContext();
+	return initialLuciaContext.user;
 };

--- a/packages/sveltekit/src/server/crypto.ts
+++ b/packages/sveltekit/src/server/crypto.ts
@@ -1,0 +1,5 @@
+import crypto from "crypto";
+
+export const generateChecksum = (input: string) => {
+	return crypto.createHash("md5").update(input).digest("hex");
+};

--- a/packages/sveltekit/src/server/hooks.ts
+++ b/packages/sveltekit/src/server/hooks.ts
@@ -15,6 +15,7 @@ const setPageDataGlobalVariable = ({ html }: { html: string }) => {
 		scriptTagMatch,
 		`${scriptTagMatch}
     window._luciaPageData = ${pageDataFunctionMatch};
+	window._luciaHooksRanLast = true;
     `
 	);
 	return html;

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -29,13 +29,21 @@ export type GlobalWindow = Window & {
 	_luciaPageData?: {
 		data: any;
 	}[];
-	_luciaHooksRanLast?: boolean
+	_luciaHooksRanLast?: boolean;
 };
 
 export type PageData = {
 	_lucia?: LuciaContext;
 };
 
+/*
+session checksum is a hash of the session id
+this hash can be used to check if the session id has changed
+without exposing the session id
+
+uses md5, which has a collision weakness
+but is good enough for non-password hashing use case
+*/
 export type LuciaContext =
 	| {
 			user: Readonly<User>;

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -24,9 +24,24 @@ export type RequestEvent = {
 };
 
 export type GlobalWindow = Window & {
-	_userStore?: Readable<User | null>;
-	_setUserStore?: (user: User | null) => void;
+	_luciaStore?: Readable<LuciaContext>;
+	_setLuciaStore?: (value: LuciaContext) => void;
 	_luciaPageData?: {
 		data: any;
 	}[];
+	_luciaHooksRanLast?: boolean
 };
+
+export type PageData = {
+	_lucia?: LuciaContext;
+};
+
+export type LuciaContext =
+	| {
+			user: Readonly<User>;
+			sessionChecksum: string;
+	  }
+	| {
+			user: null;
+			sessionChecksum: null;
+	  };

--- a/test-apps/sveltekit/src/routes/+layout.svelte
+++ b/test-apps/sveltekit/src/routes/+layout.svelte
@@ -3,7 +3,9 @@
 	import { handleSession } from '@lucia-auth/sveltekit/client';
 	import '../app.css';
 
-	handleSession(page);
+	handleSession(page, () => {
+		console.log("session change")
+	});
 </script>
 
 <svelte:head>

--- a/test-apps/sveltekit/src/routes/login/+page.server.ts
+++ b/test-apps/sveltekit/src/routes/login/+page.server.ts
@@ -1,7 +1,6 @@
 import { invalid, type Actions } from '@sveltejs/kit';
 import { auth } from '$lib/server/lucia';
 
-
 export const actions: Actions = {
 	default: async ({ request, locals }) => {
 		const form = await request.formData();


### PR DESCRIPTION
- [Breaking] `handleSession()` no longer sync sessions across tabs
- `handleSession()` can take an optional callback that will be called on session change 