### PR TITLE
Fix `testAdapter` finishing before all tests are run

### DIFF
--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
+### v0.1.4
+
+- Fix `testAdapter` test suite so it runs all tests
+
 ### v0.1.2
 
 - Update peer dependency
-

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Tests for database adapters for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-test/src/tests/index.ts
+++ b/packages/adapter-test/src/tests/index.ts
@@ -13,8 +13,8 @@ export const testAdapter = async (adapter: Adapter, db: Database, endProcess = t
 		await db.clearUsers();
 	};
 	await clearAll();
-	await testUserAdapter(adapter, db);
-	await testSessionAdapter(adapter, db);
+	await testUserAdapter(adapter, db, false);
+	await testSessionAdapter(adapter, db, false);
 	await test("getSessionAndUserBySessionId()", "Return the correct user and session", async () => {
 		if (!adapter.getSessionAndUserBySessionId) return;
 		const user = new User();


### PR DESCRIPTION
Currently, the `testAdapter` test suite finishes after `testUserAdapter` and does not execute the remaining tests due to the `endProcess` parameter in `testUserAdapter` defaulting to true. 

This change sets the `endProcess` parameter in `testUserAdapter` and `testSessionAdapter` to false so the entire test suite can run to completion.

Making this a draft PR since I'm not sure what you want to do for the package version.