### PR TITLE
[fix] Removed "avatar_url" from TwitchUser

### DIFF
--- a/documentation/src/pages/oauth/providers/twitch.md
+++ b/documentation/src/pages/oauth/providers/twitch.md
@@ -138,7 +138,6 @@ interface TwitchUser {
 	id: string; // user id
 	login: string; // username
 	display_name: string;
-	avatar_url: string;
 	type: "" | "admin" | "staff" | "global_mod";
 	broadcaster_type: "" | "affiliate" | "partner";
 	description: string;

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/oauth/src/twitch.ts
+++ b/packages/oauth/src/twitch.ts
@@ -86,7 +86,6 @@ interface TwitchUser {
 	id: string;
 	login: string;
 	display_name: string;
-	avatar_url: string;
 	type: "" | "admin" | "staff" | "global_mod";
 	broadcaster_type: "" | "affiliate" | "partner";
 	description: string;


### PR DESCRIPTION
Accidentally left in "avatar_url" which is not a property that exists in the User response from Twitch.