### PR TITLE
await user in @lucia-auth/sveltekit

### DIFF
--- a/packages/sveltekit/src/server/server-load.ts
+++ b/packages/sveltekit/src/server/server-load.ts
@@ -13,7 +13,7 @@ export const handleServerSession: HandleServerSession = (fn) => {
 		if (session) {
 			return {
 				_lucia: {
-					user,
+					user: await user,
 					sessionChecksum: generateChecksum(session.sessionId)
 				}
 			};


### PR DESCRIPTION
Fixes crucial bug caused by pending Promise returned from load function. Caused by async transformUserData being left as a pending promise

This is the error caused if the bug is left like this:
```
Data returned from `load` while rendering / is not serializable: Cannot stringify arbitrary non-POJOs (data._lucia.user)
```

This is the returned value before
```js
{
  _lucia: {
    user: Promise { [Object] },
    sessionChecksum: '...'
  }
}
```

This is the expected return value
```js
{
  _lucia: {
    user: {
      userId: '...',
      username: '....',
      handle: 'mavthedev'
    },
    sessionChecksum: '...'
  }
}
```

To work around this, you can change your +layout.server.ts to this 
```ts
import { handleServerSession } from "@lucia-auth/sveltekit";
import type { LayoutServerLoad } from "./$types";

export const load: LayoutServerLoad = async (e) => {
    const data = await (handleServerSession())(e)
    data._lucia.user = await data._lucia.user
    return data
}
```