### PR TITLE
Ignore `getSessionAndUserBySessionId()` when using normal adapters as partial adapters

### DIFF
--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.2
+
+- [Fix] Ignore `getSessionAndUserBySessionId()` if a normal adapter is provided as a user or session adapter
+
 ## 0.2.1
 
 - Remove node dependencies (`crypto`, `util`) [#236](https://github.com/pilcrowOnPaper/lucia-auth/issues/236)

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "A simple yet flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -49,11 +49,20 @@ export class Auth<C extends Configurations = any> {
 			sameSite: "lax",
 			path: "/"
 		};
+		if ("user" in configs.adapter) {
+			if ("getSessionAndUserBySessionId" in configs.adapter.user) {
+				delete configs.adapter.user.getSessionAndUserBySessionId;
+			}
+			if ("getSessionAndUserBySessionId" in configs.adapter.session) {
+				delete configs.adapter.session.getSessionAndUserBySessionId;
+			}
+		}
+		const adapter =
+			"user" in configs.adapter
+				? { ...configs.adapter.user, ...configs.adapter.session }
+				: configs.adapter;
 		this.configs = {
-			adapter:
-				"user" in configs.adapter
-					? { ...configs.adapter.user, ...configs.adapter.session }
-					: configs.adapter,
+			adapter,
 			generateCustomUserId: configs.generateCustomUserId || (async () => null),
 			env: configs.env,
 			csrfProtection: configs.csrfProtection || true,
@@ -131,8 +140,8 @@ interface Configurations {
 	adapter:
 		| Adapter
 		| {
-				user: UserAdapter;
-				session: SessionAdapter;
+				user: UserAdapter | Adapter;
+				session: SessionAdapter | Adapter;
 		  };
 	env: Env;
 	generateCustomUserId?: () => Promise<string | null>;


### PR DESCRIPTION
### `lucia-auth` v0.2.2

- [Fix] Ignore `getSessionAndUserBySessionId()` if a normal adapter is provided as a user or session adapter