### PR TITLE
export `Configurations` type

### DIFF
--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.2
+
+- Export `Configurations` type
+
 ## 0.3.1
 
 - Fix return type for `lucia()`

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "A simple yet flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -323,7 +323,7 @@ export class Auth<C extends Configurations = any> {
 
 type MaybePromise<T> = T | Promise<T>;
 
-interface Configurations {
+export interface Configurations {
 	adapter:
 		| Adapter
 		| {

--- a/packages/lucia-auth/src/index.ts
+++ b/packages/lucia-auth/src/index.ts
@@ -1,4 +1,4 @@
-export { lucia as default, SESSION_COOKIE_NAME } from "./auth/index.js";
+export { lucia as default, Configurations, SESSION_COOKIE_NAME } from "./auth/index.js";
 export { LuciaError } from "./auth/error.js";
 export { generateRandomString } from "./utils/crypto.js";
 export { serializeCookie } from "./utils/cookie.js";

--- a/packages/lucia-auth/src/index.ts
+++ b/packages/lucia-auth/src/index.ts
@@ -1,4 +1,4 @@
-export { lucia as default, Configurations, SESSION_COOKIE_NAME } from "./auth/index.js";
+export { lucia as default, type Configurations, SESSION_COOKIE_NAME } from "./auth/index.js";
 export { LuciaError } from "./auth/error.js";
 export { generateRandomString } from "./utils/crypto.js";
 export { serializeCookie } from "./utils/cookie.js";


### PR DESCRIPTION
It is useful to have this public so end users can properly type the generic of `Auth` type.

```ts
// This is in a library. See how using `Configurations` would be nice.
export function doThing<C extends Configurations = any>(auth: Auth<C>) {}

// The rest of this code is in the users project
export const auth = lucia({
  adapter: prisma(db),
  env: import.meta.env.DEV ? "DEV" : "PROD",
});

doThing(auth);
```