### PR TITLE
Add analytics to docs

### DIFF
--- a/documentation/src/components/structure/BaseLayout.astro
+++ b/documentation/src/components/structure/BaseLayout.astro
@@ -34,6 +34,11 @@ const getExternalName = (external: ExternalIntegration) => {
 		href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
 		rel="stylesheet"
 	/>
+	<script
+		data-goatcounter="https://lucia.goatcounter.com/count"
+		async
+		src="//gc.zgo.at/count.js"
+	></script>
 
 	<script is:inline>
 		const getTheme = () => {

--- a/documentation/src/components/structure/BaseLayout.astro
+++ b/documentation/src/components/structure/BaseLayout.astro
@@ -35,6 +35,7 @@ const getExternalName = (external: ExternalIntegration) => {
 		rel="stylesheet"
 	/>
 	<script
+		is:inline
 		data-goatcounter="https://lucia.goatcounter.com/count"
 		async
 		src="//gc.zgo.at/count.js"


### PR DESCRIPTION
This PR adds [GoatCounter]() analytics to the docs. It should be unintrusive, privacy friendly, and gdpr compliant. 