### PR TITLE
Fix `handleHooks()` types for `@lucia-auth/sveltekit`

### DIFF
--- a/packages/sveltekit/CHANGELOG.md
+++ b/packages/sveltekit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.1
+
+- [Fix] Fix `handleHooks()` types [#260](https://github.com/pilcrowOnPaper/lucia-auth/issues/260)
+
 ## 0.5.0
 
 - [Breaking] Renamed `locals.getSession()` to `locals.validate()`, `locals.getSessionUser()` to `locals.validateUser()`

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/sveltekit",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "SvelteKit integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -15,6 +15,13 @@ export type RequestEvent = {
 		delete: any;
 		serialize: any;
 	};
+	fetch: any;
+	getClientAddress: any;
+	platform: any;
+	params: any;
+	route: any;
+	setHeaders: any;
+	isDataRequest: any;
 };
 
 export type GlobalWindow = Window & {


### PR DESCRIPTION
## Changes

### `@lucia-auth/sveltekit` 0.5.1

- [Fix] Fix `handleHooks()` types #260