### PR TITLE
Fix OAuth redirect for sveltekit test-app

### DIFF
--- a/test-apps/sveltekit/README.md
+++ b/test-apps/sveltekit/README.md
@@ -19,6 +19,7 @@ npx prisma migrate dev --name init
 ### Github OAuth
 
 Create a Github OAuth app and copy-paste client id and secret into `.env`.
+Set the Authorization callback URL of your Github OAuth app to `http://localhost:5173/api/oauth/github/`
 
 ## Run
 

--- a/test-apps/sveltekit/src/routes/api/oauth/github/+server.ts
+++ b/test-apps/sveltekit/src/routes/api/oauth/github/+server.ts
@@ -16,10 +16,10 @@ export const GET: RequestHandler = async ({ cookies, url, locals }) => {
 			}));
 		const session = await auth.createSession(user.userId);
 		locals.setSession(session);
-		throw redirect(302, '/');
 	} catch {
 		return new Response(null, {
 			status: 500
 		});
 	}
+	throw redirect(302, '/');
 };


### PR DESCRIPTION
The redirect wasn't working for me. The redirect got caught in the try/catch. I fixed the problem.
I also updated the Readme in case someone wonders what the callback URL should look like without looking at the routing.