### PR TITLE
Update adapters

### DIFF
--- a/documentation/collection/main/learn/adapters/fauna.md
+++ b/documentation/collection/main/learn/adapters/fauna.md
@@ -6,24 +6,18 @@ title: "Fauna"
 An adapter for Fauna database.
 
 ```ts
-const adapter: (
-	faunaClient: FaunaClient,
-	errorHandler?: (error: FaunaError) => void
-) => Adapter;
+const adapter: (faunaClient: FaunaClient) => AdapterFunction<Adapter>;
 ```
 
 ### Parameter
 
-`handleError()` may be provided which will be called on [unknown errors](/learn/basics/error-handling#known-errors) - database errors Lucia doesn't expect the adapter to catch. You can also throw custom errors inside it, which will be thrown when an unknown database error occurs inside [`Lucia`](/reference/api/server-api#lucia-default) methods.
-
-| name        | type       | description           | optional |
-|-------------|------------|-----------------------| -------- |
-| faunaClient | `Client`   | Fauna client instance |          |
-| handleError | `Function` |                       | true     |
+| name        | type     | description           | optional |
+| ----------- | -------- | --------------------- | -------- |
+| faunaClient | `Client` | Fauna client instance |          |
 
 ### Errors
 
-When an adapter encounters an unknown error (described above), it will throw `FaunaError`.
+The adapter and Lucia will not not handle [unknown errors](/learn/basics/error-handling#known-errors), database errors Lucia doesn't expect the adapter to catch. When it encounters such errors, it will throw a `FaunaError`.
 
 ## Installation
 
@@ -42,7 +36,7 @@ import faunadb from "faunadb";
 const { Client } = faunadb;
 
 const auth = lucia({
-	adapter: fauna(new Client({...options}))
+	adapter: fauna(new Client(options))
 });
 ```
 
@@ -81,35 +75,37 @@ This is not required if you're only using the Fauna adapter for the `user` table
 Run the following commands inside of the Shell tab in the Fauna dashboard to setup the appropriate collections and indexes.
 
 Create collections:
+
 ```js
-CreateCollection({ name: "user" })
-CreateCollection({ name: "session" })
+CreateCollection({ name: "user" });
+CreateCollection({ name: "session" });
 ```
 
 Create Indexes:
+
 ```js
 CreateIndex({
-  name: "user_by_id",
-  source: Collection("user"),
-  unique: true,
-  terms: [{ field: ["data", "id"] }]
-})
+	name: "user_by_id",
+	source: Collection("user"),
+	unique: true,
+	terms: [{ field: ["data", "id"] }]
+});
 CreateIndex({
-  name: "session_by_id",
-  source: Collection("sessions"),
-  unique: true,
-  terms: [{ field: ["data", "id"] }]
-})
+	name: "session_by_id",
+	source: Collection("sessions"),
+	unique: true,
+	terms: [{ field: ["data", "id"] }]
+});
 CreateIndex({
-  name: "session_by_userid",
-  source: Collection("sessions"),
-  unique: true,
-  terms: [{ field: ["data", "user_id"] }]
-})
+	name: "session_by_userid",
+	source: Collection("sessions"),
+	unique: true,
+	terms: [{ field: ["data", "user_id"] }]
+});
 CreateIndex({
-    name: "user_by_providerid",
-    source: Collection("users"),
-    unique: true,
-    terms: [{ field: ["data", "provider_id"] }]
-})
+	name: "user_by_providerid",
+	source: Collection("users"),
+	unique: true,
+	terms: [{ field: ["data", "provider_id"] }]
+});
 ```

--- a/documentation/collection/main/learn/adapters/kysely.md
+++ b/documentation/collection/main/learn/adapters/kysely.md
@@ -8,24 +8,20 @@ An adapter for [Kysely SQL query builder](https://github.com/koskimas/kysely). T
 ```ts
 const adapter: (
 	db: Kysely<DB>
-	errorHandler?: (error: DatabaseError) => void
-) => Adapter;
+) => AdapterFunction<Adapter>;
 ```
 
 ### Parameter
 
 See [Database interfaces](#database-interfaces) for more information regarding the DB type used for the Kysely instance.
 
-`handleError()` may be provided which will be called on [unknown errors](/learn/basics/error-handling#known-errors) - database errors Lucia doesn't expect the adapter to catch. You can also throw custom errors inside it, which will be thrown when an unknown database error occurs inside [`Lucia`](/reference/api/server-api#lucia-default) methods.
-
 | name        | type         | description     | optional |
 | ----------- | ------------ | --------------- | -------- |
 | db          | `Kysely<DB>` | Kysely instance |          |
-| handleError | `Function`   |                 | true     |
 
 ### Errors
 
-When an adapter encounters an unknown error (described above), it will throw `DatabaseError`.
+The adapter and Lucia will not not handle [unknown errors](/learn/basics/error-handling#known-errors), database errors Lucia doesn't expect the adapter to catch. When it encounters such errors, it will throw a `DatabaseError` from `pg`.
 
 ## Installation
 

--- a/documentation/collection/main/learn/adapters/mongoose.md
+++ b/documentation/collection/main/learn/adapters/mongoose.md
@@ -6,25 +6,22 @@ title: "Mongoose (MongoDB)"
 An adapter for Mongoose (MongoDB).
 
 ```ts
-const adapter: (mongoose: Mongoose, handleError?: (error: MongooseError) => void) => Adapter;
+const adapter: (mongoose: Mongoose) => AdapterFunction<Adapter>;
 ```
 
-**This adapter does NOT support auto user id generation.** Generate your own user id using Lucia's [`generateUserId()`](/reference/configure/lucia-configurations#generatecustomuserid) in the configurations or use Mongoose's default field value. In either cases, the returned value **MUST** be a string (not `ObjectId`).
+If [`generateUserId()`](/reference/configure/lucia-configurations#generatecustomuserid) is not configured, the adapter will generate a new `ObjectId` and use the stringified version (24-character hexadecimal string) as the user id.
 
 This adapter will not handle database connection and you will need to connect to the database manually.
 
 ### Parameter
 
-`handleError()` may be provided which will be called on [unknown errors](/learn/basics/error-handling#known-errors) - database errors Lucia doesn't expect the adapter to catch. You can also throw custom errors inside it, which will be thrown when an unknown database error occurs inside [`Lucia`](/reference/api/server-api#lucia-default) methods.
-
-| name        | type       | description     | optional |
-| ----------- | ---------- | --------------- | -------- |
-| mongoose    | `Mongoose` | Mongoose client |          |
-| handleError | `Function` |                 | true     |
+| name     | type       | description     | optional |
+| -------- | ---------- | --------------- | -------- |
+| mongoose | `Mongoose` | Mongoose client |          |
 
 ### Errors
 
-When an adapter encounters an unknown error (described above), it will throw `MongooseError`.
+The adapter and Lucia will not not handle [unknown errors](/learn/basics/error-handling#known-errors), database errors Lucia doesn't expect the adapter to catch. When it encounters such errors, it will throw a `MongooseError`.
 
 ## Installation
 

--- a/documentation/collection/main/learn/adapters/prisma.md
+++ b/documentation/collection/main/learn/adapters/prisma.md
@@ -6,31 +6,18 @@ title: "Prisma"
 An adapter for Prisma ORM. Can be used with: SQL, MySQL, PostgreSQL, and SQLite.
 
 ```ts
-const adapter: (
-	client: PrismaClient,
-	handleError?: (
-		error:
-			| Prisma.PrismaClientKnownRequestError
-			| Prisma.PrismaClientValidationError
-			| Prisma.PrismaClientUnknownRequestError
-			| Prisma.PrismaClientInitializationError
-			| Prisma.PrismaClientRustPanicError
-	) => void
-) => Adapter;
+const adapter: (client: PrismaClient) => AdapterFunction<Adapter>;
 ```
 
 ### Parameter
 
-`handleError()` may be provided which will be called on [unknown errors](/learn/basics/error-handling#known-errors) - database errors Lucia doesn't expect the adapter to catch. You can also throw custom errors inside it, which will be thrown when an unknown database error occurs inside [`Lucia`](/reference/api/server-api#lucia-default) methods.
-
-| name        | type           | description   | optional |
-| ----------- | -------------- | ------------- | -------- |
-| client      | `PrismaClient` | Prisma client |          |
-| handleError | `Function`     |               | true     |
+| name   | type           | description   | optional |
+| ------ | -------------- | ------------- | -------- |
+| client | `PrismaClient` | Prisma client |          |
 
 ### Errors
 
-When an adapter encounters an unknown error (described above), it will throw one of:
+The adapter and Lucia will not not handle [unknown errors](/learn/basics/error-handling#known-errors), database errors Lucia doesn't expect the adapter to catch. When it encounters such errors, it will throw one of:
 
 - `Prisma.PrismaClientKnownRequestError`
 - `Prisma.PrismaClientValidationError`

--- a/documentation/collection/main/learn/adapters/redis.md
+++ b/documentation/collection/main/learn/adapters/redis.md
@@ -6,22 +6,22 @@ title: "Redis (session)"
 A session adapter for Redis.
 
 ```ts
-const adapter: (
-	redisClient: {
-		session: RedisClientType;
-		userSessions: RedisClientType;
-	},
-	handleError?: (error: any) => void
-) => SessionAdapter;
+const adapter: (redisClient: {
+	session: RedisClientType;
+	userSessions: RedisClientType;
+}) => AdapterFunction<SessionAdapter>;
 ```
 
-#### Parameter
+### Parameter
 
 | name                     | type            | description                                                   | optional |
 | ------------------------ | --------------- | ------------------------------------------------------------- | -------- |
 | redisClient.session      | RedisClientType | client for Redis database for storing sessions                |          |
 | redisClient.userSessions | RedisClientType | client for Redis database for storing user-sessions relations |          |
-| handleError              | `Function`      |                                                               | true     |
+
+### Errors
+
+The adapter and Lucia will not not handle [unknown errors](/learn/basics/error-handling#known-errors), database errors Lucia doesn't expect the adapter to catch. When it encounters such errors, it will throw one of Redis errors.
 
 ## Installation
 

--- a/documentation/collection/main/learn/adapters/supabase.md
+++ b/documentation/collection/main/learn/adapters/supabase.md
@@ -6,26 +6,19 @@ title: "Supabase"
 An adapter for Supabase PostgreSQL database - can be used regardless of the Supabase version. **Make sure to enable row level security for all tables!**.
 
 ```ts
-const adapter: (
-	url: string,
-	secret: string,
-	errorHandler?: (error: PostgrestError) => void
-) => Adapter;
+const adapter: (url: string, secret: string) => AdapterFunction<Adapter>;
 ```
 
 ### Parameter
 
-`handleError()` may be provided which will be called on [unknown errors](/learn/basics/error-handling#known-errors) - database errors Lucia doesn't expect the adapter to catch. You can also throw custom errors inside it, which will be thrown when an unknown database error occurs inside [`Lucia`](/reference/api/server-api#lucia-default) methods.
-
-| name        | type       | description                         | optional |
-| ----------- | ---------- | ----------------------------------- | -------- |
-| url         | `string`   | Supabase project url                |          |
-| secret      | `string`   | `service_role` secret; NOT anon key |          |
-| handleError | `Function` |                                     | true     |
+| name   | type     | description                         | optional |
+| ------ | -------- | ----------------------------------- | -------- |
+| url    | `string` | Supabase project url                |          |
+| secret | `string` | `service_role` secret; NOT anon key |          |
 
 ### Errors
 
-When an adapter encounters an unknown error (described above), it will throw `PostgrestError`.
+The adapter and Lucia will not not handle [unknown errors](/learn/basics/error-handling#known-errors), database errors Lucia doesn't expect the adapter to catch. When an adapter encounters such errors, it will throw a `PostgrestError`.
 
 ## Installation
 

--- a/documentation/collection/main/reference/adapters/api.md
+++ b/documentation/collection/main/reference/adapters/api.md
@@ -3,7 +3,9 @@ _order: 1
 title: "API"
 ---
 
-Adapters are just objects with a handful of methods that interact with the database. This makes it pretty easy to create your own and support any databases. Adapters can throw errors as well.
+Adapters are just objects with a handful of methods that interact with the database. This makes it easy to create your own and support any databases. 
+
+The `adapter` configuration expects a [`AdapterFunction`](), which are functions that takes a [`LuciaError`]() constructor as its parameter and returns an adapter object. **`LuciaError` thrown by adapters should use the constructor and not the one imported from `lucia-auth` package**.
 
 Refer to [Database model](/reference/adapters/database-model) for database model and types.
 

--- a/documentation/collection/main/reference/configure/lucia-configurations.md
+++ b/documentation/collection/main/reference/configure/lucia-configurations.md
@@ -9,10 +9,10 @@ Configurations for `lucia()`.
 interface Configurations {
 	// required
 	adapter:
-		| Adapter
+		| AdapterFunction<Adapter>
 		| {
-				user: UserAdapter;
-				session: SessionAdapter;
+				user: AdapterFunction<UserAdapter>;
+				session: AdapterFunction<SessionAdapter>;
 		  };
 	env: Env;
 
@@ -47,27 +47,27 @@ type CookieOption = {
 
 An adapter for your database. If you're using a single database:
 
-| type      |
-| --------- |
-| `Adapter` |
+| type                                                                                                            |
+| --------------------------------------------------------------------------------------------------------------- |
+| [`AdapterFunction`](/reference/adapters/api#adapterfunction)`<`[`Adapter`](/reference/adapters/api#adapter) `>` |
 
-or, if you're using a different adapter for `user` and `session` table. A normal `Adapter` can be used for both `adapter.user` and `adapter.session`
+or, it can take a different adapter for each table. A normal `Adapter` can be used for both `adapter.user` and `adapter.session`
 
 #### `user` (required)
 
-An adapter for the database that stores users - can be a normal [`Adapter`](/reference/adapters/api#adapter) adapter.
+An adapter for the database that stores users. Can be a normal `AdapterFunction<Adapter>` adapter.
 
-| type                                                      |
-| --------------------------------------------------------- |
-| [`UserAdapter`](/reference/types/lucia-types#useradapter) |
+| type                                                                           |
+| ------------------------------------------------------------------------------ |
+| `AdapterFunction<`[`UserAdapter`](/reference/types/lucia-types#useradapter)`>` |
 
 #### `session` (required)
 
 An adapter for the database that stores sessions.
 
-| type                                                         |
-| ------------------------------------------------------------ |
-| [`SessionAdapter`](/reference/types/lucia-types#useradapter) |
+| type                                                                              |
+| --------------------------------------------------------------------------------- |
+| `AdapterFunction<`[`SessionAdapter`](/reference/types/lucia-types#useradapter)`>` |
 
 ### `env`
 
@@ -87,13 +87,15 @@ Will remove [dead sessions](/learn/start-here/concepts#session-states) from the 
 | --------- | ------- |
 | `boolean` | `true`  |
 
-Specifically, it removes the target session from the database if its dead on: 
+Specifically, it removes the target session from the database if its dead on:
+
 - `getSession()`
 - `getSessionUser()`
 - `validateSessionUser()`
 - `validateSession()`
 
-and deletes the target user's dead sessions from the database on: 
+and deletes the target user's dead sessions from the database on:
+
 - `updateUserProviderId()`
 - `updateUserAttributes()`
 - `createSession()`.

--- a/documentation/collection/main/reference/types/lucia-types.md
+++ b/documentation/collection/main/reference/types/lucia-types.md
@@ -3,15 +3,25 @@ _order: 0
 title: "Lucia types"
 ---
 
-Types can be imported from `lucia-auth/types`.
+Types can be imported from `lucia-auth`.
 
 ```ts
-import type { Adapter } from "lucia-auth/types";
+import type { Adapter } from "lucia-auth";
 ```
 
 ## `Adapter`
 
 Refer to [Adapters](/reference/adapters/api) reference.
+
+## `AdapterFunction`
+
+Refer to [Adapters](/reference/adapters/api) reference. `LuciaErrorConstructor` is the constructor function (class reference) of [`LuciaError`](/reference/types/lucia-types#luciaerror).
+
+```ts
+export type AdapterFunction<A extends Adapter | UserAdapter | SessionAdapter> = (
+	LuciaError: LuciaErrorConstructor
+) => A;
+```
 
 ## `Auth`
 

--- a/examples/astro/prisma/schema.prisma
+++ b/examples/astro/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id              String    @id @unique @default(cuid())
   provider_id     String    @unique
   hashed_password String?
-  username        String?   @unique
+  username        String    @unique
   session         Session[]
 
   @@map("user")

--- a/examples/nextjs/prisma/schema.prisma
+++ b/examples/nextjs/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id              String    @id @unique @default(cuid())
   provider_id     String    @unique
   hashed_password String?
-  username        String?   @unique
+  username        String    @unique
   session         Session[]
 
   @@map("user")

--- a/examples/sveltekit/prisma/schema.prisma
+++ b/examples/sveltekit/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id              String    @id @unique @default(cuid())
   provider_id     String    @unique
   hashed_password String?
-  username        String?   @unique
+  username        String    @unique
   session         Session[]
 
   @@map("user")

--- a/packages/adapter-fauna/CHANGELOG.md
+++ b/packages/adapter-fauna/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.2.0
+
+- [Breaking] Require `lucia-auth` 0.4.0
+- [Breaking] Remove global error handler
+- Clean up code
+
 ## 0.1.1
 
 - Add auto user id generation

--- a/packages/adapter-fauna/README.md
+++ b/packages/adapter-fauna/README.md
@@ -17,8 +17,9 @@ npm install @lucia-auth/adapter-fauna
 ## Lucia version compatibility
 
 | Fauna adapter version | Lucia version |
-|-----------------------| ------------- |
+| --------------------- | ------------- |
 | 0.1.x                 | 0.1.x ~ 0.3.x |
+| 0.2.x                 | 0.4.x ~       |
 
 ## Testing
 

--- a/packages/adapter-fauna/package.json
+++ b/packages/adapter-fauna/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-fauna",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Fauna adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -34,7 +34,7 @@
 		".": "./index.js"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.4.x"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",

--- a/packages/adapter-fauna/src/utils.ts
+++ b/packages/adapter-fauna/src/utils.ts
@@ -1,21 +1,35 @@
-export function convertUserResponse(res: any) {
-	const array: any[] = [];
-	res.forEach((row: { data: { [x: string]: any; id: any; hashed_password: any; provider_id: any } }) => {
-		const { id, hashed_password, provider_id, ...attributes } = row.data;
-		array.push({
-			id, provider_id, hashed_password: hashed_password === undefined ? null : hashed_password, ...attributes
-		});
-	});
-	return array;
-}
+import { UserSchema } from "lucia-auth";
 
-export function convertSessionResponse(res: any) {
-	const array: any[] = [];
-	res.forEach((row: { data: { id: any; user_id: any; expires: any; idle_expires: any; }; }) => {
-		const { id, user_id, expires, idle_expires } = row.data;
-		array.push({
-			id, user_id, expires, idle_expires
-		});
-	});
-	return array;
-}
+export type MultiResponse<T> = {
+	data: {
+		data: T;
+	}[];
+};
+
+export type SingleResponse<T> = {
+	data: T;
+};
+
+export type FaunaUserSchema = {
+	id: string;
+	hashed_password?: string;
+	provider_id: string;
+	[k: string]: any;
+};
+
+export type FaunaSessionSchema = {
+	id: string;
+	user_id: string;
+	expires: number;
+	idle_expires: number;
+};
+
+export const convertUserResponse = (res: SingleResponse<FaunaUserSchema>): UserSchema => {
+	const { id, hashed_password, provider_id, ...attributes } = res.data;
+	return {
+		id,
+		provider_id,
+		hashed_password: hashed_password ?? null,
+		...attributes
+	}
+};

--- a/packages/adapter-kysely/CHANGELOG.md
+++ b/packages/adapter-kysely/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.0
+
+- [Breaking] Require `lucia-auth` 0.4.0
+- [Breaking] Remove global error handler
+
 ## 0.1.1
 
 - Update peer dependency

--- a/packages/adapter-kysely/README.md
+++ b/packages/adapter-kysely/README.md
@@ -19,6 +19,7 @@ npm install @lucia-auth/adapter-kysely
 | Kysely adapter version | Lucia version |
 | ---------------------- | ------------- |
 | 0.1.x                  | 0.1.x ~ 0.2.x |
+| 0.2.x                  | 0.4.x ~       |
 
 ## Testing
 

--- a/packages/adapter-kysely/package.json
+++ b/packages/adapter-kysely/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-kysely",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Kysely adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -36,7 +36,7 @@
 		".": "./index.js"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.4.x"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",

--- a/packages/adapter-kysely/src/utils.ts
+++ b/packages/adapter-kysely/src/utils.ts
@@ -1,4 +1,4 @@
-import type { SessionSchema } from "lucia-auth/types";
+import type { SessionSchema } from "lucia-auth";
 import type { Selectable } from "kysely";
 import type { Session } from "./dbTypes";
 

--- a/packages/adapter-kysely/test/db.ts
+++ b/packages/adapter-kysely/test/db.ts
@@ -8,6 +8,7 @@ import { convertSession } from "../src/utils.js";
 
 import dotenv from "dotenv";
 import { resolve } from "path";
+import { LuciaError } from "lucia-auth";
 
 dotenv.config({
 	path: `${resolve()}/.env`
@@ -29,7 +30,7 @@ const dbKysely = new Kysely<DBExt>({
 	})
 });
 
-export const adapter = adapterKysely(dbKysely);
+export const adapter = adapterKysely(dbKysely)(LuciaError);
 
 export const db: Database = {
 	getUsers: async () => {

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.2.0
+
+- [Breaking] Require `lucia-auth` 0.4.0
+- [Breaking] Remove global error handler
+- Generates a new `ObjectId` and uses a 24-character hexadecimal representation of it as the user id if none is provided
+
 ## 0.1.5
 
 - Update peer dependency

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [Breaking] Require `lucia-auth` 0.4.0
 - [Breaking] Remove global error handler
-- Generates a new `ObjectId` and uses a 24-character hexadecimal representation of it as the user id if none is provided
+- Generates a new `ObjectId` and uses its 24-character hexadecimal representation as the user id if none is provided
 
 ## 0.1.5
 

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -21,6 +21,7 @@ yarn add @lucia-auth/adapter-mongoose
 | Mongoose adapter version | Lucia version |
 | ------------------------ | ------------- |
 | 0.1.x                    | 0.1.x ~ 0.3.x |
+| 0.2.x                    | 0.4.x ~       |
 
 ## Testing
 

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-mongoose",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"description": "Mongoose (MongoDB) adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -35,7 +35,7 @@
 		".": "./index.js"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.4.x"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",

--- a/packages/adapter-mongoose/src/index.ts
+++ b/packages/adapter-mongoose/src/index.ts
@@ -1,40 +1,26 @@
-import { LuciaError } from "lucia-auth";
 import { getUpdateData } from "lucia-auth/adapter";
-import type { Adapter } from "lucia-auth/types";
 import Mongoose from "mongoose";
 import { convertSessionDoc, convertUserDoc } from "./utils.js";
+import type { Adapter, AdapterFunction } from "lucia-auth";
 
-const adapter = (
-	mongoose: Mongoose.Mongoose,
-	errorHandler: (error: Mongoose.MongooseError) => void = () => {}
-): Adapter => {
+const adapter = (mongoose: Mongoose.Mongoose): AdapterFunction<Adapter> => {
 	const User = mongoose.model<UserDoc>("user");
 	const Session = mongoose.model<SessionDoc>("session");
-	return {
-		getUser: async (userId: string) => {
-			try {
+	return (LuciaError) => {
+		return {
+			getUser: async (userId: string) => {
 				const userDoc = await User.findById(userId).lean();
 				if (!userDoc) return null;
 				return convertUserDoc(userDoc);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getUserByProviderId: async (providerId) => {
-			try {
+			},
+			getUserByProviderId: async (providerId) => {
 				const user = await User.findOne({
 					provider_id: providerId
 				}).lean();
 				if (!user) return null;
 				return convertUserDoc(user);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSessionAndUserBySessionId: async (sessionId) => {
-			try {
+			},
+			getSessionAndUserBySessionId: async (sessionId) => {
 				const session = await Session.findById(sessionId).lean();
 				if (!session) return null;
 				const user = await User.findById(session.user_id).lean();
@@ -43,119 +29,90 @@ const adapter = (
 					user: convertUserDoc(user),
 					session: convertSessionDoc(session)
 				};
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSession: async (sessionId) => {
-			try {
+			},
+			getSession: async (sessionId) => {
 				const session = await Session.findById(sessionId).lean();
 				if (!session) return null;
 				return convertSessionDoc(session);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSessionsByUserId: async (userId) => {
-			try {
+			},
+			getSessionsByUserId: async (userId) => {
 				const sessions = await Session.find({
 					user_id: userId
 				}).lean();
 				return sessions.map((val) => convertSessionDoc(val));
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		setUser: async (userId, data) => {
-			try {
-				const newUserDoc = new User({
-					_id: userId || undefined,
-					hashed_password: data.hashedPassword,
-					provider_id: data.providerId,
-					...data.attributes
-				});
-				const userDoc = await newUserDoc.save();
-				const user = convertUserDoc(userDoc.toObject());
-				return user;
-			} catch (e) {
-				const error = e as Mongoose.MongooseError;
-				if (error.message.includes("E11000") && error.message.includes("provider_id"))
-					throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteUser: async (userId: string) => {
-			try {
+			},
+			setUser: async (userId, data) => {
+				try {
+					const newUserDoc = new User({
+						_id: userId ?? new Mongoose.Types.ObjectId().toString(),
+						hashed_password: data.hashedPassword,
+						provider_id: data.providerId,
+						...data.attributes
+					});
+					const userDoc = await newUserDoc.save();
+					const user = convertUserDoc(userDoc.toObject());
+					return user;
+				} catch (error) {
+					if (
+						error instanceof Mongoose.MongooseError &&
+						error.message.includes("E11000") &&
+						error.message.includes("provider_id")
+					)
+						throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+					throw error;
+				}
+			},
+			deleteUser: async (userId: string) => {
 				await User.findOneAndDelete({
 					_id: userId
 				});
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		setSession: async (sessionId, data) => {
-			let userDoc: UserDoc | null = null;
-			try {
-				userDoc = await User.findById(data.userId);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-			if (!userDoc) throw new LuciaError("AUTH_INVALID_USER_ID");
-			try {
-				const sessionDoc = new Session({
-					_id: sessionId,
-					user_id: data.userId,
-					expires: data.expires,
-					idle_expires: data.idlePeriodExpires
-				});
-				await Session.create(sessionDoc);
-			} catch (e) {
-				const error = e as Mongoose.MongooseError;
-				if (error.message.includes("E11000") && error.message.includes("id"))
-					throw new LuciaError("AUTH_DUPLICATE_SESSION_ID");
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteSession: async (sessionId) => {
-			try {
+			},
+			setSession: async (sessionId, data) => {
+				const userDoc = await User.findById(data.userId);
+				if (!userDoc) throw new LuciaError("AUTH_INVALID_USER_ID");
+				try {
+					const sessionDoc = new Session({
+						_id: sessionId,
+						user_id: data.userId,
+						expires: data.expires,
+						idle_expires: data.idlePeriodExpires
+					});
+					await Session.create(sessionDoc);
+				} catch (error) {
+					if (
+						error instanceof Mongoose.MongooseError &&
+						error.message.includes("E11000") &&
+						error.message.includes("id")
+					)
+						throw new LuciaError("AUTH_DUPLICATE_SESSION_ID");
+					throw error;
+				}
+			},
+			deleteSession: async (sessionId) => {
 				await Session.findByIdAndDelete(sessionId);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteSessionsByUserId: async (userId) => {
-			try {
+			},
+			deleteSessionsByUserId: async (userId) => {
 				await Session.deleteMany({
 					user_id: userId
 				});
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
+			},
+			updateUser: async (userId, newData) => {
+				const partialData = getUpdateData(newData);
+				try {
+					const userDoc = await User.findByIdAndUpdate(userId, partialData).lean();
+					if (!userDoc) throw new LuciaError("AUTH_INVALID_USER_ID");
+					return convertUserDoc(userDoc);
+				} catch (error) {
+					if (
+						error instanceof Mongoose.MongooseError &&
+						error.message.includes("E11000") &&
+						error.message.includes("provider_id")
+					)
+						throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+					throw error;
+				}
 			}
-		},
-		updateUser: async (userId, newData) => {
-			const partialData = getUpdateData(newData);
-			try {
-				const userDoc = await User.findByIdAndUpdate(userId, partialData).lean();
-				if (!userDoc) throw new LuciaError("AUTH_INVALID_USER_ID");
-				return convertUserDoc(userDoc);
-			} catch (e) {
-				if (e instanceof LuciaError) throw e;
-				const error = e as Mongoose.MongooseError;
-				if (error.message.includes("E11000") && error.message.includes("provider_id"))
-					throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
-				errorHandler(e as any);
-				throw e;
-			}
-		}
+		};
 	};
 };
 

--- a/packages/adapter-mongoose/src/utils.ts
+++ b/packages/adapter-mongoose/src/utils.ts
@@ -1,4 +1,4 @@
-import type { SessionSchema, UserSchema } from "lucia-auth/types";
+import type { SessionSchema, UserSchema } from "lucia-auth";
 
 export const convertUserDoc = (row: UserDoc): UserSchema => {
 	const { _id: id, __v: _, $__, _doc, hashed_password, provider_id, ...attributes } = row;

--- a/packages/adapter-mongoose/test/db.ts
+++ b/packages/adapter-mongoose/test/db.ts
@@ -5,6 +5,7 @@ import mongodb from "../src/index.js";
 import dotenv from "dotenv";
 import { resolve } from "path";
 import { convertSessionDoc } from "../src/utils.js";
+import { LuciaError } from "lucia-auth";
 
 dotenv.config({
 	path: `${resolve()}/.env`
@@ -62,7 +63,7 @@ const Session = mongoose.model(
 );
 const clientPromise = mongoose.connect(url);
 
-export const adapter = mongodb(mongoose);
+export const adapter = mongodb(mongoose)(LuciaError);
 
 const inputToMongooseDoc = (obj: Record<string, any>) => {
 	if (obj.id === undefined) return obj;

--- a/packages/adapter-prisma/CHANGELOG.md
+++ b/packages/adapter-prisma/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.0
+
+- [Breaking] Require `lucia-auth` 0.4.0
+- [Breaking] Remove global error handler
+
 ## 0.1.4
 
 - Update peer dependency

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -21,6 +21,7 @@ yarn add @lucia-auth/adapter-prisma
 | prisma adapter version | Lucia version |
 | ---------------------- | ------------- |
 | 0.1.x                  | 0.1.x ~ 0.3.x |
+| 0.2.x                  | 0.4.x ~       |
 
 ## Testing
 

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-prisma",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"description": "Prisma adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -34,7 +34,7 @@
 		".": "./index.js"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.4.x"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -1,28 +1,18 @@
-import type { Prisma, PrismaClient } from "@prisma/client";
-import type { Adapter } from "lucia-auth";
+import type { PrismaClient } from "@prisma/client";
+import type { Adapter, AdapterFunction } from "lucia-auth";
 import { getUpdateData } from "lucia-auth/adapter";
-import { LuciaError } from "lucia-auth";
 import { convertSession } from "./utils.js";
 
 interface PossiblePrismaError {
-	code?: string;
-	message?: string;
+	code: string;
+	message: string;
 }
 
-const adapter = (
-	prisma: PrismaClient,
-	errorHandler: (
-		error:
-			| Prisma.PrismaClientKnownRequestError
-			| Prisma.PrismaClientValidationError
-			| Prisma.PrismaClientUnknownRequestError
-			| Prisma.PrismaClientInitializationError
-			| Prisma.PrismaClientRustPanicError
-	) => void = () => {}
-): Adapter => {
-	return {
-		getUser: async (userId) => {
-			try {
+const adapter =
+	(prisma: PrismaClient): AdapterFunction<Adapter> =>
+	(LuciaError) => {
+		return {
+			getUser: async (userId) => {
 				const data = await prisma.user.findUnique({
 					where: {
 						id: userId
@@ -30,13 +20,8 @@ const adapter = (
 				});
 				if (!data) return null;
 				return data;
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSessionAndUserBySessionId: async (sessionId) => {
-			try {
+			},
+			getSessionAndUserBySessionId: async (sessionId) => {
 				const data = await prisma.session.findUnique({
 					where: {
 						id: sessionId
@@ -51,13 +36,8 @@ const adapter = (
 					user: user,
 					session: convertSession(session)
 				};
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getUserByProviderId: async (providerId) => {
-			try {
+			},
+			getUserByProviderId: async (providerId) => {
 				const data = await prisma.user.findUnique({
 					where: {
 						provider_id: providerId
@@ -65,13 +45,8 @@ const adapter = (
 				});
 				if (!data) return null;
 				return data;
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSession: async (sessionId) => {
-			try {
+			},
+			getSession: async (sessionId) => {
 				const session = await prisma.session.findUnique({
 					where: {
 						id: sessionId
@@ -79,132 +54,104 @@ const adapter = (
 				});
 				if (!session) return null;
 				return convertSession(session);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSessionsByUserId: async (userId) => {
-			try {
+			},
+			getSessionsByUserId: async (userId) => {
 				const sessions = await prisma.session.findMany({
 					where: {
 						user_id: userId
 					}
 				});
 				return sessions.map((session) => convertSession(session));
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		setUser: async (userId, data) => {
-			try {
-				if (userId === null) {
+			},
+			setUser: async (userId, data) => {
+				try {
+					if (userId === null) {
+						const createdUser = await prisma.user.create({
+							data: {
+								provider_id: data.providerId,
+								hashed_password: data.hashedPassword,
+								...data.attributes
+							} as any
+						});
+						return createdUser;
+					}
 					const createdUser = await prisma.user.create({
 						data: {
+							id: userId,
 							provider_id: data.providerId,
 							hashed_password: data.hashedPassword,
 							...data.attributes
 						} as any
 					});
 					return createdUser;
+				} catch (e) {
+					const error = e as Partial<PossiblePrismaError>;
+					if (error.code === "P2002" && error.message?.includes("provider_id")) {
+						throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+					}
+					throw error;
 				}
-				const createdUser = await prisma.user.create({
-					data: {
-						id: userId,
-						provider_id: data.providerId,
-						hashed_password: data.hashedPassword,
-						...data.attributes
-					} as any
-				});
-				return createdUser;
-			} catch (e) {
-				const error = e as PossiblePrismaError;
-				if (error.code === "P2002" && error.message?.includes("provider_id")) {
-					throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
-				}
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteUser: async (userId) => {
-			try {
+			},
+			deleteUser: async (userId) => {
 				await prisma.user.deleteMany({
 					where: {
 						id: userId
 					}
 				});
-				return;
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		setSession: async (sessionId, data) => {
-			try {
-				await prisma.session.create({
-					data: {
-						id: sessionId,
-						user_id: data.userId,
-						expires: data.expires,
-						idle_expires: data.idlePeriodExpires
-					}
-				});
-			} catch (e) {
-				const error = e as PossiblePrismaError;
-				if (error.code === "P2003" && error.message?.includes("session_user_id_fkey (index)"))
-					throw new LuciaError("AUTH_INVALID_USER_ID");
-				if (error.code === "P2002" && error.message?.includes("id"))
-					throw new LuciaError("AUTH_DUPLICATE_SESSION_ID");
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteSession: async (sessionId) => {
-			try {
+			},
+			setSession: async (sessionId, data) => {
+				try {
+					await prisma.session.create({
+						data: {
+							id: sessionId,
+							user_id: data.userId,
+							expires: data.expires,
+							idle_expires: data.idlePeriodExpires
+						}
+					});
+				} catch (e) {
+					const error = e as Partial<PossiblePrismaError>;
+					if (error.code === "P2003" && error.message?.includes("session_user_id_fkey (index)"))
+						throw new LuciaError("AUTH_INVALID_USER_ID");
+					if (error.code === "P2002" && error.message?.includes("id"))
+						throw new LuciaError("AUTH_DUPLICATE_SESSION_ID");
+					throw error;
+				}
+			},
+			deleteSession: async (sessionId) => {
 				await prisma.session.delete({
 					where: {
 						id: sessionId
 					}
 				});
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteSessionsByUserId: async (userId) => {
-			try {
+			},
+			deleteSessionsByUserId: async (userId) => {
 				await prisma.session.deleteMany({
 					where: {
 						user_id: userId
 					}
 				});
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		updateUser: async (userId, newData) => {
-			const partialData = getUpdateData(newData);
-			try {
-				const data = await prisma.user.update({
-					data: partialData,
-					where: {
-						id: userId
+			},
+			updateUser: async (userId, newData) => {
+				const partialData = getUpdateData(newData);
+				try {
+					const data = await prisma.user.update({
+						data: partialData,
+						where: {
+							id: userId
+						}
+					});
+					return data;
+				} catch (e) {
+					const error = e as Partial<PossiblePrismaError>;
+					if (error.code === "P2025") throw new LuciaError("AUTH_INVALID_USER_ID");
+					if (error.code === "P2002" && error.message?.includes("provider_id")) {
+						throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
 					}
-				});
-				return data;
-			} catch (e) {
-				const error = e as PossiblePrismaError;
-				if (error.code === "P2025") throw new LuciaError("AUTH_INVALID_USER_ID");
-				if (error.code === "P2002" && error.message?.includes("provider_id")) {
-					throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+					throw error;
 				}
-				errorHandler(e as any);
-				throw e;
 			}
-		}
+		};
 	};
-};
 
 export default adapter;

--- a/packages/adapter-prisma/src/utils.ts
+++ b/packages/adapter-prisma/src/utils.ts
@@ -1,5 +1,5 @@
 import { Session } from "@prisma/client";
-import type { SessionSchema } from "lucia-auth/types";
+import type { SessionSchema } from "lucia-auth";
 
 export const convertSession = (session: Session): SessionSchema => {
 	const { expires, idle_expires: idleExpires, ...data } = session;

--- a/packages/adapter-prisma/test/db.ts
+++ b/packages/adapter-prisma/test/db.ts
@@ -2,9 +2,10 @@ import { Database } from "@lucia-auth/adapter-test";
 import { PrismaClient } from "@prisma/client";
 import prisma from "../src/index.js";
 import { convertSession } from "../src/utils.js";
+import { LuciaError } from "lucia-auth";
 
 const client = new PrismaClient();
-export const adapter = prisma(client);
+export const adapter = prisma(client)(LuciaError);
 
 export const db: Database = {
 	getUsers: async () => {

--- a/packages/adapter-supabase/CHANGELOG.md
+++ b/packages/adapter-supabase/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.0
+
+- [Breaking] Require `lucia-auth` 0.4.0
+- [Breaking] Remove global error handler
+
 ## 0.1.5
 
 - Update peer dependency

--- a/packages/adapter-supabase/README.md
+++ b/packages/adapter-supabase/README.md
@@ -19,6 +19,7 @@ npm install @lucia-auth/adapter-supabase
 | Supabase adapter version | Lucia version |
 | ------------------------ | ------------- |
 | 0.1.x                    | 0.1.x ~ 0.3.x |
+| 0.2.x                    | 0.4.x ~       |
 
 ## Testing
 

--- a/packages/adapter-supabase/package.json
+++ b/packages/adapter-supabase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-supabase",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"description": "Supabase adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -33,7 +33,7 @@
 		".": "./index.js"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.4.x"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",

--- a/packages/adapter-supabase/src/index.ts
+++ b/packages/adapter-supabase/src/index.ts
@@ -1,7 +1,6 @@
 import { PostgrestClient } from "@supabase/postgrest-js"; // Supabase's realtime breaks adapter
-import { LuciaError } from "lucia-auth";
 import { getUpdateData } from "lucia-auth/adapter";
-import type { Adapter, UserSchema, SessionSchema } from "lucia-auth";
+import type { Adapter, UserSchema, SessionSchema, AdapterFunction } from "lucia-auth";
 
 type PostgrestError = {
 	details: string | null;
@@ -34,193 +33,167 @@ type PostgrestPossibleErrorResult = {
 	error: PostgrestError | null;
 };
 
-const adapter = (
-	url: string,
-	secret: string,
-	errorHandler: (error: PostgrestError) => void = () => {}
-): Adapter => {
+const adapter = (url: string, secret: string): AdapterFunction<Adapter> => {
 	const supabase = new PostgrestClient(`${url}/rest/v1`, {
 		headers: {
 			Authorization: `Bearer ${secret}`,
 			apikey: secret
 		}
 	});
-	return {
-		getUser: async (userId) => {
-			const { data, error } = (await supabase
-				.from<UserSchema>("user")
-				.select()
-				.eq("id", userId)
-				.maybeSingle()) as PostgrestSingleResult<UserSchema>;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-			if (!data) return null;
-			return data;
-		},
-		getUserByProviderId: async (providerId) => {
-			const { data, error } = (await supabase
-				.from<UserSchema>("user")
-				.select()
-				.eq("provider_id", providerId)
-				.maybeSingle()) as PostgrestSingleResult<UserSchema>;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-			if (!data) return null;
-			return data;
-		},
-		getSessionAndUserBySessionId: async (sessionId) => {
-			type Schema = SessionSchema & { user: UserSchema };
-			const { data, error } = (await supabase
-				.from<Schema>("session")
-				.select("user(*), *")
-				.eq("id", sessionId)
-				.maybeSingle()) as PostgrestSingleResult<Schema>;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-			if (!data) return null;
-			const { user, ...session } = data;
-			return {
-				user,
-				session
-			};
-		},
-		getSession: async (sessionId) => {
-			const { data, error } = (await supabase
-				.from<SessionSchema>("session")
-				.select("*, user(*)")
-				.eq("id", sessionId)
-				.maybeSingle()) as PostgrestSingleResult<SessionSchema>;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-			if (!data) return null;
-			return data;
-		},
-		getSessionsByUserId: async (userId) => {
-			const { data, error } = (await supabase
-				.from<SessionSchema>("session")
-				.select("*, user(*)")
-				.eq("user_id", userId)) as PostgrestMultipleResult<SessionSchema>;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-			return (
-				data?.map((val) => {
-					return val;
-				}) || []
-			);
-		},
-		setUser: async (userId, userData) => {
-			const { data, error } = (await supabase
-				.from<UserSchema>("user")
-				.insert(
+	return (LuciaError) => {
+		return {
+			getUser: async (userId) => {
+				const { data, error } = (await supabase
+					.from<UserSchema>("user")
+					.select()
+					.eq("id", userId)
+					.maybeSingle()) as PostgrestSingleResult<UserSchema>;
+				if (error) throw error;
+				return data;
+			},
+			getUserByProviderId: async (providerId) => {
+				const { data, error } = (await supabase
+					.from<UserSchema>("user")
+					.select()
+					.eq("provider_id", providerId)
+					.maybeSingle()) as PostgrestSingleResult<UserSchema>;
+				if (error) throw error;
+				if (!data) return null;
+				return data;
+			},
+			getSessionAndUserBySessionId: async (sessionId) => {
+				type Schema = SessionSchema & { user: UserSchema };
+				const { data, error } = (await supabase
+					.from<Schema>("session")
+					.select("user(*), *")
+					.eq("id", sessionId)
+					.maybeSingle()) as PostgrestSingleResult<Schema>;
+				if (error) throw error;
+				const { user, ...session } = data;
+				return {
+					user,
+					session
+				};
+			},
+			getSession: async (sessionId) => {
+				const { data, error } = (await supabase
+					.from<SessionSchema>("session")
+					.select("*, user(*)")
+					.eq("id", sessionId)
+					.maybeSingle()) as PostgrestSingleResult<SessionSchema>;
+				if (error) throw error;
+				return data;
+			},
+			getSessionsByUserId: async (userId) => {
+				const { data, error } = (await supabase
+					.from<SessionSchema>("session")
+					.select("*, user(*)")
+					.eq("user_id", userId)) as PostgrestMultipleResult<SessionSchema>;
+				if (error) throw error;
+				return (
+					data?.map((val) => {
+						return val;
+					}) || []
+				);
+			},
+			setUser: async (userId, userData) => {
+				const { data, error } = (await supabase
+					.from<UserSchema>("user")
+					.insert(
+						{
+							id: userId || undefined,
+							provider_id: userData.providerId,
+							hashed_password: userData.hashedPassword,
+							...userData.attributes
+						},
+						{
+							returning: "representation"
+						}
+					)
+					.single()) as PostgrestSingleResult<UserSchema>;
+				if (error) {
+					if (
+						error.details?.includes("(provider_id)") &&
+						error.details.includes("already exists.")
+					) {
+						throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+					}
+					throw error;
+				}
+				return data;
+			},
+			deleteUser: async (userId) => {
+				const { error } = (await supabase
+					.from<UserSchema>("user")
+					.delete({
+						returning: "minimal"
+					})
+					.eq("id", userId)) as PostgrestSingleResult<UserSchema>;
+				if (error) throw error;
+			},
+			setSession: async (sessionId, data) => {
+				const { error } = (await supabase.from<SessionSchema>("session").insert(
 					{
-						id: userId || undefined,
-						provider_id: userData.providerId,
-						hashed_password: userData.hashedPassword,
-						...userData.attributes
+						id: sessionId,
+						expires: data.expires,
+						idle_expires: data.idlePeriodExpires,
+						user_id: data.userId
 					},
 					{
-						returning: "representation"
+						returning: "minimal"
 					}
-				)
-				.single()) as PostgrestSingleResult<UserSchema>;
-			if (error) {
-				if (error.details?.includes("(provider_id)") && error.details.includes("already exists.")) {
-					throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+				)) as PostgrestSingleResult<UserSchema>;
+				if (error) {
+					if (
+						error.details?.includes("is not present in table") &&
+						error.details.includes("user_id")
+					) {
+						throw new LuciaError("AUTH_INVALID_USER_ID");
+					}
+					if (error.details?.includes("(id)") && error.details.includes("already exists.")) {
+						throw new LuciaError("AUTH_DUPLICATE_SESSION_ID");
+					}
+					throw error;
 				}
-				errorHandler(error);
-				throw error;
-			}
-			return data;
-		},
-		deleteUser: async (userId) => {
-			const { error } = (await supabase
-				.from<UserSchema>("user")
-				.delete({
-					returning: "minimal"
-				})
-				.eq("id", userId)) as PostgrestSingleResult<UserSchema>;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-		},
-		setSession: async (sessionId, data) => {
-			const { error } = (await supabase.from<SessionSchema>("session").insert(
-				{
-					id: sessionId,
-					expires: data.expires,
-					idle_expires: data.idlePeriodExpires,
-					user_id: data.userId
-				},
-				{
-					returning: "minimal"
+			},
+			deleteSession: async (...sessionIds) => {
+				const { error } = (await supabase
+					.from<SessionSchema>("session")
+					.delete({
+						returning: "minimal"
+					})
+					.in("id", sessionIds)) as PostgrestPossibleErrorResult;
+				if (error) throw error;
+			},
+			deleteSessionsByUserId: async (userId) => {
+				const { error } = (await supabase
+					.from<SessionSchema>("session")
+					.delete({
+						returning: "minimal"
+					})
+					.eq("user_id", userId)) as PostgrestPossibleErrorResult;
+				if (error) throw error;
+			},
+			updateUser: async (userId, newData) => {
+				const dbData = getUpdateData(newData);
+				const { data, error } = (await supabase
+					.from<UserSchema>("user")
+					.update(dbData)
+					.eq("id", userId)
+					.maybeSingle()) as PostgrestSingleResult<UserSchema>;
+				if (error) {
+					if (
+						error.details?.includes("(provider_id)") &&
+						error.details.includes("already exists.")
+					) {
+						throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
+					}
+					throw error;
 				}
-			)) as PostgrestSingleResult<UserSchema>;
-			if (error) {
-				if (
-					error.details?.includes("is not present in table") &&
-					error.details.includes("user_id")
-				) {
-					throw new LuciaError("AUTH_INVALID_USER_ID");
-				}
-				if (error.details?.includes("(id)") && error.details.includes("already exists.")) {
-					throw new LuciaError("AUTH_DUPLICATE_SESSION_ID");
-				}
-				errorHandler(error);
-				throw error;
+				if (!data) throw new LuciaError("AUTH_INVALID_USER_ID");
+				return data;
 			}
-		},
-		deleteSession: async (...sessionIds) => {
-			const { error } = (await supabase
-				.from<SessionSchema>("session")
-				.delete({
-					returning: "minimal"
-				})
-				.in("id", sessionIds)) as PostgrestPossibleErrorResult;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-		},
-		deleteSessionsByUserId: async (userId) => {
-			const { error } = (await supabase
-				.from<SessionSchema>("session")
-				.delete({
-					returning: "minimal"
-				})
-				.eq("user_id", userId)) as PostgrestPossibleErrorResult;
-			if (error) {
-				errorHandler(error);
-				throw error;
-			}
-		},
-		updateUser: async (userId, newData) => {
-			const dbData = getUpdateData(newData);
-			const { data, error } = (await supabase
-				.from<UserSchema>("user")
-				.update(dbData)
-				.eq("id", userId)
-				.maybeSingle()) as PostgrestSingleResult<UserSchema>;
-			if (error) {
-				if (error.details?.includes("(provider_id)") && error.details.includes("already exists.")) {
-					throw new LuciaError("AUTH_DUPLICATE_PROVIDER_ID");
-				}
-				errorHandler(error);
-				throw error;
-			}
-			if (!data) throw new LuciaError("AUTH_INVALID_USER_ID");
-			return data;
-		}
+		};
 	};
 };
 

--- a/packages/adapter-supabase/test/db.ts
+++ b/packages/adapter-supabase/test/db.ts
@@ -4,7 +4,7 @@ import supabase from "../src/index.js";
 
 import dotenv from "dotenv";
 import { resolve } from "path";
-import type { SessionSchema, UserSchema } from "lucia-auth";
+import { LuciaError, SessionSchema, UserSchema } from "lucia-auth";
 
 dotenv.config({
 	path: `${resolve()}/.env`
@@ -22,7 +22,7 @@ const client = new PostgrestClient(`${url}/rest/v1`, {
 	}
 });
 
-export const adapter = supabase(url, secret);
+export const adapter = supabase(url, secret)(LuciaError);
 
 export const db: Database = {
 	getUsers: async () => {

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.6
 
+- Update peer dependency
 - Clean up code
 
 ## 0.1.5

--- a/packages/adapter-test/CHANGELOG.md
+++ b/packages/adapter-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.6
+
+- Clean up code
+
 ## 0.1.5
 
 - Update peer dependency

--- a/packages/adapter-test/README.md
+++ b/packages/adapter-test/README.md
@@ -20,4 +20,4 @@ yarn add -D @lucia-auth/adapter-test
 
 | test adapter version | Lucia version |
 | -------------------- | ------------- |
-| 0.1.x                | 0.1.x ~ 0.3.x |
+| 0.1.x                | 0.1.x ~ 0.4.x |

--- a/packages/adapter-test/package.json
+++ b/packages/adapter-test/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/adapter-test",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Tests for database adapters for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -42,6 +42,6 @@
 		"cli-color": "^2.0.3"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.1.x - 0.4.x"
 	}
 }

--- a/packages/adapter-test/src/db.ts
+++ b/packages/adapter-test/src/db.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import type { SessionSchema, UserSchema } from "lucia-auth/types";
+import type { SessionSchema, UserSchema } from "lucia-auth";
 
 const generateRandomString = (bytes: number) => {
 	return crypto.randomBytes(bytes).toString("hex");

--- a/packages/adapter-test/src/index.ts
+++ b/packages/adapter-test/src/index.ts
@@ -1,4 +1,4 @@
-import { SessionSchema, UserSchema } from "lucia-auth/types";
+import { SessionSchema, UserSchema } from "lucia-auth";
 export { testAdapter } from "./tests/index.js";
 export { testAdapterUserIdGeneration } from "./tests/user-id.js";
 export { testSessionAdapter } from "./tests/session.js";

--- a/packages/adapter-test/src/test.ts
+++ b/packages/adapter-test/src/test.ts
@@ -25,7 +25,7 @@ const isTrueValidation = (result: boolean, error: string, ...log: any[]) => {
 };
 
 export const validate = {
-	includesSomeItem: <T extends any>(
+	includesSomeItem: <T extends string | number | {}>(
 		arr: T[],
 		validate: (t: T) => boolean,
 		error: string,
@@ -33,7 +33,7 @@ export const validate = {
 	) => {
 		isTrueValidation(arr.some(validate), error, arr, ...log);
 	},
-	notIncludesSomeItem: <T extends any>(
+	notIncludesSomeItem: <T extends string | number | {}>(
 		arr: T[],
 		validate: (t: T) => boolean,
 		error: string,

--- a/packages/adapter-test/src/tests/index.ts
+++ b/packages/adapter-test/src/tests/index.ts
@@ -1,4 +1,4 @@
-import type { SessionSchema, UserSchema, Adapter } from "lucia-auth/types";
+import type { SessionSchema, UserSchema, Adapter } from "lucia-auth";
 import { test, end, validate } from "./../test.js";
 import { User } from "./../db.js";
 import { Database } from "../index.js";

--- a/packages/adapter-test/src/tests/session.ts
+++ b/packages/adapter-test/src/tests/session.ts
@@ -1,4 +1,4 @@
-import type { SessionAdapter } from "lucia-auth/types";
+import type { SessionAdapter } from "lucia-auth";
 import { test, end, validate } from "../test.js";
 import { User } from "../db.js";
 import { Database } from "../index.js";

--- a/packages/adapter-test/src/tests/user-id.ts
+++ b/packages/adapter-test/src/tests/user-id.ts
@@ -1,4 +1,4 @@
-import type { Adapter } from "lucia-auth/types";
+import type { Adapter } from "lucia-auth";
 import { test, end, validate } from "./../test.js";
 import { User } from "./../db.js";
 import { Database } from "./../index.js";

--- a/packages/adapter-test/src/tests/user.ts
+++ b/packages/adapter-test/src/tests/user.ts
@@ -1,4 +1,4 @@
-import type { UserAdapter, UserSchema } from "lucia-auth/types";
+import type { UserAdapter, UserSchema } from "lucia-auth";
 import { test, end, validate } from "../test.js";
 import { User } from "../db.js";
 import { Database } from "../index.js";

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4.1
+
+- Update peer dependency
+
 ## 0.4.0
 
 - [Breaking] Renamed `authRequest.validate()` to `AuthRequest.validate()`, `authRequest.validateUser()` to `AuthRequest.validateUser()`

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/astro",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Lucia integration for Astro",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -45,6 +45,6 @@
 		"lucia-auth": "workspace:*"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.3.x"
+		"lucia-auth": "0.3.x - 0.4.x"
 	}
 }

--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.4.0
+
+- [Breaking] Adapters are now functions that return the `Adapter` object
+- Export type `LuciaErrorConstructor`, `AdapterFunction`
+
 ## 0.3.4
 
 - Add `AUTO_USER_ID_GENERATION_NOT_SUPPORTED` error

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "0.3.4",
+	"version": "0.4.0",
 	"description": "A simple yet flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/src/auth/error.ts
+++ b/packages/lucia-auth/src/auth/error.ts
@@ -8,6 +8,12 @@ export class LuciaError extends Error {
 	public message: ErrorMessage;
 }
 
+type Constructor<C extends new (...args: any[]) => any> = new (
+	...args: ConstructorParameters<C>
+) => InstanceType<C>;
+
+export type LuciaErrorConstructor = Constructor<typeof LuciaError>;
+
 export type ErrorMessage =
 	| "AUTH_INVALID_SESSION_ID"
 	| "AUTH_INVALID_PASSWORD"

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -7,7 +7,7 @@ import {
 	generateRandomString,
 	validateScryptHash
 } from "../utils/crypto.js";
-import { LuciaError } from "./error.js";
+import { LuciaError, LuciaErrorConstructor } from "./error.js";
 import { parseCookie } from "../utils/cookie.js";
 import { getSessionFromDatabaseData } from "./session.js";
 
@@ -60,8 +60,8 @@ export class Auth<C extends Configurations = any> {
 		}
 		this.adapter =
 			"user" in configs.adapter
-				? { ...configs.adapter.user, ...configs.adapter.session }
-				: configs.adapter;
+				? { ...configs.adapter.user(LuciaError), ...configs.adapter.session(LuciaError) }
+				: configs.adapter(LuciaError);
 		this.generateUserId = configs.generateCustomUserId ?? (async () => null);
 		this.env = configs.env;
 		this.csrfProtection = configs.csrfProtection ?? true;
@@ -325,10 +325,10 @@ type MaybePromise<T> = T | Promise<T>;
 
 export interface Configurations {
 	adapter:
-		| Adapter
+		| ((E: LuciaErrorConstructor) => Adapter)
 		| {
-				user: UserAdapter | Adapter;
-				session: SessionAdapter | Adapter;
+				user: (E: LuciaErrorConstructor) => UserAdapter | Adapter;
+				session: (E: LuciaErrorConstructor) => SessionAdapter | Adapter;
 		  };
 	env: Env;
 	generateCustomUserId?: () => Promise<string | null>;

--- a/packages/lucia-auth/src/index.ts
+++ b/packages/lucia-auth/src/index.ts
@@ -1,5 +1,5 @@
 export { lucia as default, type Configurations, SESSION_COOKIE_NAME } from "./auth/index.js";
-export { LuciaError } from "./auth/error.js";
+export { LuciaError, LuciaErrorConstructor } from "./auth/error.js";
 export { generateRandomString } from "./utils/crypto.js";
 export { serializeCookie } from "./utils/cookie.js";
 export * from "./types.js";

--- a/packages/lucia-auth/src/types.ts
+++ b/packages/lucia-auth/src/types.ts
@@ -1,3 +1,5 @@
+import type { LuciaErrorConstructor } from "./index.js";
+
 export type { Auth } from "./auth/index.js";
 
 export type User = ReturnType<Lucia.Auth["transformUserData"]>;
@@ -8,7 +10,7 @@ export type Session = {
 	activePeriodExpires: Date;
 	idlePeriodExpires: Date;
 	state: "idle" | "active";
-	isFresh: boolean
+	isFresh: boolean;
 };
 
 export type Env = "DEV" | "PROD";
@@ -27,6 +29,10 @@ export type SessionSchema = {
 	idle_expires: number;
 	user_id: string;
 };
+
+export type AdapterFunction<T extends Adapter | UserAdapter | SessionAdapter> = (
+	E: LuciaErrorConstructor
+) => T;
 
 export type Adapter = {
 	getSessionAndUserBySessionId?: (sessionId: string) => Promise<{

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4.1
+
+- Update peer dependency
+
 ## 0.4.0
 
 - [Breaking] Renamed `authRequest.validate()` to `AuthRequest.validate()`, `authRequest.validateUser()` to `AuthRequest.validateUser()`

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/nextjs",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Lucia integration for Next.js",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -45,6 +45,6 @@
 		"lucia-auth": "workspace:*"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.3.x"
+		"lucia-auth": "0.3.x - 0.4.x"
 	}
 }

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -6,13 +6,13 @@ export const handleApiRoutes = (auth: Auth) => {
 	return async (req: NextRequest, res: NextResponse) => {
 		if (!res.status) throw new Error("Invalid response type");
 		const authRequest = new AuthRequest(auth, req, res);
-		if ((req.url || "").startsWith("/api/auth/user") && req.method === "GET") {
+		if ((req.url ?? "").startsWith("/api/auth/user") && req.method === "GET") {
 			const { user } = await authRequest.validateUser();
 			return res.status(200).json({
 				user
 			});
 		}
-		if ((req.url || "").startsWith("/api/auth/logout") && req.method === "POST") {
+		if ((req.url ?? "").startsWith("/api/auth/logout") && req.method === "POST") {
 			const sessionId = auth.validateRequestHeaders(convertNextRequestToStandardRequest(req));
 			if (!sessionId) return res.status(200).json({});
 			try {

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.6
+
+- Update peer dependency
+
 ## 0.2.5
 
 - Add Reddit provider

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -60,6 +60,6 @@
 		"lucia-auth": "workspace:*"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.1.x - 0.4.x"
 	}
 }

--- a/packages/oauth/src/github.ts
+++ b/packages/oauth/src/github.ts
@@ -14,7 +14,7 @@ class Github<A extends Auth> implements OAuthProvider {
 		this.auth = auth;
 		this.clientId = configs.clientId;
 		this.clientSecret = configs.clientSecret;
-		this.scope = configs.scope || [];
+		this.scope = configs.scope ?? [];
 	}
 	private auth: A;
 	private clientId: string;

--- a/packages/oauth/src/google.ts
+++ b/packages/oauth/src/google.ts
@@ -17,7 +17,7 @@ class Google<A extends Auth> implements OAuthProvider {
 		this.clientId = configs.clientId;
 		this.clientSecret = configs.clientSecret;
 		this.redirectUri = configs.redirectUri;
-		this.scope = ["https://www.googleapis.com/auth/userinfo.profile", ...(configs.scope || [])];
+		this.scope = ["https://www.googleapis.com/auth/userinfo.profile", ...(configs.scope ?? [])];
 	}
 	private auth: A;
 	private clientId: string;

--- a/packages/oauth/src/patreon.ts
+++ b/packages/oauth/src/patreon.ts
@@ -21,7 +21,7 @@ class Patreon<A extends Auth> implements OAuthProvider {
 		this.scope = [
 			"identity",
 			"identity[email]",
-			...(configs.scope || []),
+			...(configs.scope ?? []),
 			...(configs.allMemberships ? ["identity.memberships"] : [])
 		];
 	}

--- a/packages/oauth/src/twitch.ts
+++ b/packages/oauth/src/twitch.ts
@@ -17,9 +17,9 @@ class Twitch<A extends Auth> implements OAuthProvider {
 		this.auth = auth;
 		this.clientId = configs.clientId;
 		this.clientSecret = configs.clientSecret;
-		this.scope = configs.scope || ["user:read:email"];
+		this.scope = configs.scope ?? ["user:read:email"];
 		this.redirectUri = configs.redirectUri;
-		this.forceVerify = configs.forceVerify || false;
+		this.forceVerify = configs.forceVerify ?? false;
 	}
 	private auth: A;
 	private clientId: string;

--- a/packages/session-adapter-redis/CHANGELOG.md
+++ b/packages/session-adapter-redis/CHANGELOG.md
@@ -1,8 +1,13 @@
 # CHANGELOG
 
+## 0.2.0
+
+- [Breaking] Require `lucia-auth` 0.4.0
+- [Breaking] Remove global error handler
+
 ## 0.1.3
 
-- [Breaking] Requires `lucia-auth` 0.3.0
+- [Breaking] Require `lucia-auth` 0.3.0
 
 ## 0.1.2
 

--- a/packages/session-adapter-redis/README.md
+++ b/packages/session-adapter-redis/README.md
@@ -16,9 +16,10 @@ npm install @lucia-auth/session-adapter-redis
 
 ## Lucia version compatibility
 
-| Session adapter version | Lucia version  |
-| ----------------------- | -------------- |
-| 0.1.x                  | 0.1.x ~ 0.3.x |
+| Redis adapter version | Lucia version |
+| --------------------- | ------------- |
+| 0.1.x                 | 0.1.x ~ 0.3.x |
+| 0.2.x                 | 0.4.x ~       |
 
 ## Testing
 

--- a/packages/session-adapter-redis/package.json
+++ b/packages/session-adapter-redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/session-adapter-redis",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"description": "Redis session adapter for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -33,15 +33,13 @@
 		".": "./index.js"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.1.x - 0.3.x"
+		"lucia-auth": "0.4.x"
 	},
 	"devDependencies": {
 		"@lucia-auth/adapter-test": "workspace:*",
 		"dotenv": "^16.0.3",
 		"redis": "^4.3.1",
-		"ts-node": "^10.9.1"
-	},
-	"dependencies": {
+		"ts-node": "^10.9.1",
 		"lucia-auth": "workspace:*"
 	}
 }

--- a/packages/session-adapter-redis/src/index.ts
+++ b/packages/session-adapter-redis/src/index.ts
@@ -1,41 +1,29 @@
-import type { SessionSchema, SessionAdapter } from "lucia-auth/types";
+import type { SessionSchema, SessionAdapter, AdapterFunction } from "lucia-auth";
 import type { RedisClientType } from "redis";
 
-const adapter = (
-	redisClient: {
+const adapter =
+	(redisClient: {
 		session: RedisClientType<any, any, any>;
 		userSessions: RedisClientType<any, any, any>;
-	},
-	errorHandler: (error: any) => void = () => {}
-): SessionAdapter => {
-	const { session: sessionRedis, userSessions: userSessionsRedis } = redisClient;
-	return {
-		getSession: async (sessionId) => {
-			try {
+	}): AdapterFunction<SessionAdapter> =>
+	() => {
+		const { session: sessionRedis, userSessions: userSessionsRedis } = redisClient;
+		return {
+			getSession: async (sessionId) => {
 				const sessionData = await sessionRedis.get(sessionId);
 				if (!sessionData) return null;
 				const session = JSON.parse(sessionData) as SessionSchema;
 				return session;
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		getSessionsByUserId: async (userId) => {
-			try {
+			},
+			getSessionsByUserId: async (userId) => {
 				const sessionIds = await userSessionsRedis.lRange(userId, 0, -1);
 				const sessionData = await Promise.all(sessionIds.map((id) => sessionRedis.get(id)));
 				const sessions = sessionData
 					.filter((val): val is string => val !== null)
 					.map((val) => JSON.parse(val) as SessionSchema);
 				return sessions;
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		setSession: async (sessionId, data) => {
-			try {
+			},
+			setSession: async (sessionId, data) => {
 				Promise.all([
 					userSessionsRedis.lPush(data.userId, sessionId),
 					sessionRedis.set(
@@ -51,13 +39,8 @@ const adapter = (
 						}
 					)
 				]);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteSession: async (...sessionIds) => {
-			try {
+			},
+			deleteSession: async (...sessionIds) => {
 				const targetSessionData = await Promise.all(sessionIds.map((id) => sessionRedis.get(id)));
 				const sessions = targetSessionData
 					.filter((val): val is string => val !== null)
@@ -66,24 +49,15 @@ const adapter = (
 					...sessionIds.map((id) => sessionRedis.del(id)),
 					...sessions.map((session) => userSessionsRedis.lRem(session.user_id, 1, session.id))
 				]);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
-			}
-		},
-		deleteSessionsByUserId: async (userId) => {
-			try {
+			},
+			deleteSessionsByUserId: async (userId) => {
 				const sessionIds = await userSessionsRedis.lRange(userId, 0, -1);
 				await Promise.all([
 					...sessionIds.map((id) => sessionRedis.del(id)),
 					userSessionsRedis.del(userId)
 				]);
-			} catch (e) {
-				errorHandler(e as any);
-				throw e;
 			}
-		}
+		};
 	};
-};
 
 export default adapter;

--- a/packages/session-adapter-redis/test/db.ts
+++ b/packages/session-adapter-redis/test/db.ts
@@ -1,8 +1,9 @@
 import type { Database } from "@lucia-auth/adapter-test";
-import type { SessionSchema } from "lucia-auth/adapter";
+import type { SessionSchema } from "lucia-auth/types.js";
 
 import { createClient } from "redis";
 import redis from "../src/index.js";
+import { LuciaError } from "lucia-auth";
 
 const sessionInstance = createClient({
 	socket: {
@@ -22,7 +23,7 @@ await userSessionInstance.connect();
 export const adapter = redis({
 	session: sessionInstance,
 	userSessions: userSessionInstance
-});
+})(LuciaError);
 
 export const db: Database = {
 	getUsers: async () => {

--- a/packages/sveltekit/CHANGELOG.md
+++ b/packages/sveltekit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.2
+
+- Update peer dependency
+
 ## 0.5.1
 
 - [Fix] Fix `handleHooks()` types [#260](https://github.com/pilcrowOnPaper/lucia-auth/issues/260)

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/sveltekit",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "SvelteKit integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",
@@ -50,7 +50,7 @@
 		"svelte": "3.x"
 	},
 	"peerDependencies": {
-		"lucia-auth": "0.3.x",
+		"lucia-auth": "0.3.x - 0.4.x",
 		"svelte": "3.x"
 	},
 	"dependencies": {

--- a/packages/sveltekit/src/server/server-load.ts
+++ b/packages/sveltekit/src/server/server-load.ts
@@ -29,7 +29,7 @@ export const handleServerSession: HandleServerSession = (fn) => {
 	};
 	return async (event: LoadEvent) => {
 		const { _lucia } = await handleServerSessionCore(event);
-		const loadFunction = fn || (async () => {});
+		const loadFunction = fn ?? (async () => {});
 		const result = (await loadFunction(event)) || {};
 		return {
 			_lucia,

--- a/test-apps/astro/prisma/schema.prisma
+++ b/test-apps/astro/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id              String    @id @unique @default(cuid())
   provider_id     String    @unique
   hashed_password String?
-  username        String?   @unique
+  username        String    @unique
   session         Session[]
 
   @@map("user")

--- a/test-apps/nextjs/lib/lucia.ts
+++ b/test-apps/nextjs/lib/lucia.ts
@@ -16,8 +16,8 @@ export const auth = lucia({
 });
 
 export const githubAuth = github(auth, {
-	clientId: process.env.GITHUB_CLIENT_ID || "",
-	clientSecret: process.env.GITHUB_CLIENT_SECRET || ""
+	clientId: process.env.GITHUB_CLIENT_ID ?? "",
+	clientSecret: process.env.GITHUB_CLIENT_SECRET ?? ""
 });
 
 export type Auth = typeof auth;

--- a/test-apps/nextjs/pages/login.tsx
+++ b/test-apps/nextjs/pages/login.tsx
@@ -45,10 +45,9 @@ const Index = () => {
 			})
 		});
 		if (response.redirected) return router.push(response.url);
-		const result =
-			((await response.json()) as {
-				error: string;
-			}) || {};
+		const result = (await response.json()) as {
+			error: string;
+		};
 		setMessage(result.error);
 	};
 	return (
@@ -69,7 +68,7 @@ const Index = () => {
 				<br />
 				<input type="submit" value="Continue" className="button" />
 			</form>
-			{message && <p className="error">{message || ""}</p>}
+			{message && <p className="error">{message ?? ""}</p>}
 			<Link href="/signup" className="link">
 				Create a new account
 			</Link>

--- a/test-apps/nextjs/pages/signup.tsx
+++ b/test-apps/nextjs/pages/signup.tsx
@@ -45,10 +45,9 @@ const Index = () => {
 			})
 		});
 		if (response.redirected) return router.push(response.url);
-		const result =
-			((await response.json()) as {
-				error: string;
-			}) || {};
+		const result = (await response.json()) as {
+			error: string;
+		};
 		setMessage(result.error);
 	};
 	return (

--- a/test-apps/nextjs/prisma/schema.prisma
+++ b/test-apps/nextjs/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id              String    @id @unique @default(cuid())
   provider_id     String    @unique
   hashed_password String?
-  username        String?   @unique
+  username        String    @unique
   session         Session[]
 
   @@map("user")

--- a/test-apps/sveltekit/prisma/schema.prisma
+++ b/test-apps/sveltekit/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id              String    @id @unique @default(cuid())
   provider_id     String    @unique
   hashed_password String?
-  username        String?   @unique
+  username        String    @unique
   session         Session[]
 
   @@map("user")


### PR DESCRIPTION
This PR changes adapters passed on to the configuration to a function. Resolves #273 

## Changes

### `lucia-auth` 0.4.0

- [Breaking] Adapters are now functions that return the `Adapter` object
- Export type `LuciaErrorConstructor`, `AdapterFunction`

### `@lucia-auth/adapter-prisma` 0.2.0,  `@lucia-auth/adapter-supabase` 0.2.0, `@lucia-auth/adapter-kysely` 0.2.0, `@lucia-auth/adapter-fauna` 0.2.0, `@lucia-auth/session-adapter-redis` 0.2.0

- [Breaking] Require `lucia-auth` 0.4.0
- [Breaking] Remove global error handler

### `@lucia-auth/adapter-mongoose` 0.2.0

- [Breaking] Require `lucia-auth` 0.4.0
- [Breaking] Remove global error handler
- Generates a new `ObjectId` and uses a 24-character hexadecimal representation of it as the user id if none is provided

### `@lucia-auth/adapter-test` 0.1.6, `@lucia-auth/sveltekit` 0.4.1, `@lucia-auth/nextjs` 0.4.1, `@lucia-auth/astro` 0.4.1, `@lucia-auth/oauth` 0.2.6

- Update peer dependency