### PR TITLE
fix createUser options type

### DIFF
--- a/documentation/collection/main/reference/api/server-api.md
+++ b/documentation/collection/main/reference/api/server-api.md
@@ -175,21 +175,24 @@ Creates a new user.
 const createUser: (
 	provider: string,
 	identifier: string,
-	options?: {
-		password?: string;
-		attributes?: Lucia.UserAttributes;
-	}
+	options:
+		| {
+				password?: string;
+				attributes?: Lucia.UserAttributes;
+		  }
+		| undefined
 ) => Promise<User>;
 ```
 
 #### Parameter
 
-| name               | type                                                                      | description                                             | optional |
-| ------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------- | -------- |
-| provider           | `string`                                                                  | the provider of the user to create                      |          |
-| identifier         | `string`                                                                  | the identifier of the user˝ to create                   |          |
-| options.password   | `string`                                                                  | the password of the user - can be undefined to omit it. | true     |
-| options.attributes | [`Lucia.UserAttributes`](/reference/types/lucia-namespace#userattributes) | Additional user data to store in `user` table           | true     |
+| name               | type                                                                                     | description                                                                                            | optional |
+| ------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------- |
+| provider           | `string`                                                                                 | the provider of the user to create                                                                     |          |
+| identifier         | `string`                                                                                 | the identifier of the user˝ to create                                                                  |          |
+| options            | `     Record<any, any<> \| undefined`                                                    | can be undefined if [`Lucia.UserAttributes`](/reference/types/lucia-namespace#userattributes) is empty |          |
+| options.password   | `string`                                                                                 | the password of the user - can be undefined to omit it.                                                | true     |
+| options.attributes | [`Lucia.UserAttributes`](/reference/types/lucia-namespace#userattributes)` \| undefined` | additional user data to store in `user` table - can be undefined if `Lucia.UserAttributes` is empty    | true     |
 
 #### Returns
 
@@ -214,11 +217,23 @@ try {
 		attributes: {
 			username: "user123",
 			isAdmin: true
-		}
+		} // required if Lucia.UserAttributes is NOT empty
 	});
 } catch {
 	// error
 }
+```
+
+These are only valid if `Lucia.attributes` ***IS*** empty:
+
+```ts
+auth.createUser("email", "user@example.com", {
+	password: "123456"
+});
+```
+
+```ts
+auth.createUser("email", "user@example.com");
 ```
 
 ### `deleteDeadUserSessions()`

--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4.1
+
+- `options.attributes` parameter for `createUser()` is only required if `Lucia.UserAttributes` has keys
+
 ## 0.4.0
 
 - [Breaking] Adapters are now functions that return the `Adapter` object

--- a/packages/lucia-auth/CHANGELOG.md
+++ b/packages/lucia-auth/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.1
 
+- `options` parameter for `createUser()` is only necessary if `Lucia.UserAttributes` has keys
 - `options.attributes` parameter for `createUser()` is only required if `Lucia.UserAttributes` has keys
 
 ## 0.4.0

--- a/packages/lucia-auth/package.json
+++ b/packages/lucia-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lucia-auth",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "A simple yet flexible authentication library",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -137,7 +137,7 @@ export class Auth<C extends Configurations = any> {
 		identifier: string,
 		options?: {
 			password?: string;
-			attributes?: Lucia.UserAttributes;
+			attributes: keyof Lucia.UserAttributes extends never ? undefined : Lucia.UserAttributes;
 		}
 	): Promise<User> => {
 		const providerId = `${provider}:${identifier}`;

--- a/packages/lucia-auth/src/auth/index.ts
+++ b/packages/lucia-auth/src/auth/index.ts
@@ -135,15 +135,25 @@ export class Auth<C extends Configurations = any> {
 	public createUser = async (
 		provider: string,
 		identifier: string,
-		options?: {
-			password?: string;
-			attributes: keyof Lucia.UserAttributes extends never ? undefined : Lucia.UserAttributes;
-		}
+		options: keyof Lucia.UserAttributes extends never
+			? undefined
+			: {
+					password?: string;
+					attributes: keyof Lucia.UserAttributes extends never ? undefined : Lucia.UserAttributes;
+			  }
 	): Promise<User> => {
 		const providerId = `${provider}:${identifier}`;
-		const attributes = options?.attributes ?? {};
+		const optionsArg = options as
+			| undefined
+			| {
+					password?: string;
+					attributes?: Lucia.UserAttributes;
+			  };
+		const attributes = optionsArg?.attributes ?? {};
 		const userId = await this.generateUserId();
-		const hashedPassword = options?.password ? await this.hash.generate(options.password) : null;
+		const hashedPassword = optionsArg?.password
+			? await this.hash.generate(optionsArg.password)
+			: null;
 		const userData = await this.adapter.setUser(userId, {
 			providerId,
 			hashedPassword: hashedPassword,


### PR DESCRIPTION
Should've fixed this one earlier. Even if you needed have `Lucia.UserAttributes` defined, this was ok (now it throws an error):

```ts
await auth.createUser(provider, identifier, {})
```

Additionally, the third argument is now optional if `Lucia.UserAttributes` is empty.

## Changes

### 0.4.1

- `options` parameter for `createUser()` is only necessary if `Lucia.UserAttributes` has keys
- `options.attributes` parameter for `createUser()` is only required if `Lucia.UserAttributes` has keys