### PR TITLE
Add user-agent header to sendRequests

### DIFF
--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.1
+
+- Add `User-Agent` header to all requests
+
 ## 0.3.0
 
 - [Breaking] Rename type `GetUserType` to `LuciaUser`; remove `GetCreateUserAttributesType`

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/oauth/src/request.ts
+++ b/packages/oauth/src/request.ts
@@ -20,6 +20,7 @@ export const sendRequest = async (url: string, method: "GET" | "POST", options?:
 	const response = await fetch(url, {
 		...(options?.body && { body: JSON.stringify(options.body) }),
 		headers: {
+			"User-Agent": "lucia",
 			Accept: "application/json",
 			...(options?.body && {
 				"Content-Type": "application/json"


### PR DESCRIPTION
Hey, the GitHub API requires the User-Agent to be set.  This is not the case for all deployment environments (e.g., Cloudflare Pages Fetch API doesn't set it by default). I suggest enforcing the User-Agent as it does no harm if already provided by the environment.