### PR TITLE
Update OAuth package

### DIFF
--- a/documentation/collection/integration/oauth/reference/api-reference.md
+++ b/documentation/collection/integration/oauth/reference/api-reference.md
@@ -84,14 +84,14 @@ interface ProviderSession {
 Creates a new user for the authorized session by calling [Lucia.createUser()](/reference/api/server-api#createuser) using the provided user attributes. Refer to the provider's doc for the provider and identifier used.
 
 ```ts
-const createUser: (userAttributes?: Lucia.UserAttributes) => Promise<User>;
+const createUser: (userAttributes: Lucia.UserAttributes | undefined) => Promise<User>;
 ```
 
 #### Parameter
 
-| name           | type                                                                      | description                                 | optional |
-| -------------- | ------------------------------------------------------------------------- | ------------------------------------------- | -------- |
-| userAttributes | [`Lucia.UserAttributes`](/reference/types/lucia-namespace#userattributes) | additional user data to store in user table | true     |
+| name           | type                                                                                     | description                                                                                                       | optional |
+| -------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------- |
+| userAttributes | [`Lucia.UserAttributes`](/reference/types/lucia-namespace#userattributes)` \| undefined` | additional user data to store in user table - **can only be `undefined` (optional) if `Lucia.UserAttributes` is an empty object type** | true     |
 
 #### Returns
 

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.3.0
+
+- [Breaking] Rename type `GetUserType` to `LuciaUser`; remove `GetCreateUserAttributesType`
+- Make `Buffer` dependency optional
+
 ## 0.2.7
 
 - Fix type issues with `existingUser` and `createUser()` for `validateCallback()`

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0
 
 - [Breaking] Rename type `GetUserType` to `LuciaUser`; remove `GetCreateUserAttributesType`
+- `userAttributes` params for `createUser()` is optional if `Lucia.UserAttributes` is empty
 - Make `Buffer` dependency optional
 
 ## 0.2.7

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/oauth",
-	"version": "0.2.7",
+	"version": "0.3.0",
 	"description": "OAuth integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -3,12 +3,8 @@ import { generateRandomString } from "lucia-auth";
 
 export interface OAuthProvider<A extends Auth> {
 	validateCallback: (code: string) => Promise<{
-		existingUser: GetUserType<A> | null;
-		createUser: (
-			userAttributes?: Parameters<A["createUser"]>[2] extends {}
-				? Parameters<A["createUser"]>[2]["attributes"]
-				: undefined
-		) => Promise<GetUserType<A>>;
+		existingUser: LuciaUser<A> | null;
+		createUser: CreateUser<A>
 		providerUser: Record<string, any>;
 		[data: string]: any;
 	}>;
@@ -32,8 +28,10 @@ export const generateState = () => {
 };
 
 export type GetAuthorizationUrlReturnType<T> = T extends null ? [string] : [string, string];
-export type GetUserType<A extends Auth> = Awaited<ReturnType<A["getUser"]>>;
-export type GetCreateUserAttributesType<A extends Auth> = Exclude<
-	Parameters<A["createUser"]>[2],
-	undefined
->["attributes"];
+export type LuciaUser<A extends Auth> = Awaited<ReturnType<A["getUser"]>>;
+export type CreateUser<A extends Auth> = Parameters<A["createUser"]>[2] extends {}
+	? (userAttributes: CreateUserAttributes<A>) => Promise<LuciaUser<A>>
+	: () => Promise<LuciaUser<A>>;
+type CreateUserAttributes<A extends Auth> = Parameters<A["createUser"]>[2] extends {}
+	? Parameters<A["createUser"]>[2]["attributes"]
+	: undefined;

--- a/packages/oauth/src/patreon.ts
+++ b/packages/oauth/src/patreon.ts
@@ -1,10 +1,10 @@
 import { post, get } from "./request.js";
 import type { Auth } from "lucia-auth";
 import {
+	CreateUser,
 	generateState,
 	GetAuthorizationUrlReturnType,
-	GetCreateUserAttributesType,
-	GetUserType,
+	LuciaUser,
 	OAuthConfig,
 	OAuthProvider
 } from "./index.js";
@@ -89,23 +89,22 @@ class Patreon<A extends Auth> implements OAuthProvider<A> {
 
 		const patreonUserId = String(patreonUser.id);
 
-		let existingUser: GetUserType<A> | null = null;
+		let existingUser: LuciaUser<A> | null = null;
 		try {
 			existingUser = (await this.auth.getUserByProviderId(
 				"patreon",
 				patreonUserId
-			)) as GetUserType<A>;
+			)) as LuciaUser<A>;
 		} catch {
 			// existingUser is null
 		}
+		const createUser = (async (userAttributes) => {
+			return await this.auth.createUser("patreon", patreonUserId, {
+				attributes: userAttributes as any
+			});
+		}) as CreateUser<A>;
 		return {
-			createUser: async (
-				userAttributes?: GetCreateUserAttributesType<A>
-			): Promise<GetUserType<A>> => {
-				return (await this.auth.createUser("patreon", patreonUserId, {
-					attributes: userAttributes
-				})) as any;
-			},
+			createUser,
 			existingUser,
 			providerUser: patreonUser,
 			accessToken,

--- a/packages/oauth/src/twitch.ts
+++ b/packages/oauth/src/twitch.ts
@@ -1,10 +1,10 @@
 import { post, get } from "./request.js";
 import type { Auth } from "lucia-auth";
 import {
+	CreateUser,
 	generateState,
 	GetAuthorizationUrlReturnType,
-	GetCreateUserAttributesType,
-	GetUserType,
+	LuciaUser,
 	OAuthConfig,
 	OAuthProvider
 } from "./index.js";
@@ -67,21 +67,19 @@ class Twitch<A extends Auth> implements OAuthProvider<A> {
 		).data[0] as TwitchUser;
 
 		const twitchUserId = String(twitchUser.id);
-		let existingUser: GetUserType<A> | null = null;
+		let existingUser: LuciaUser<A> | null = null;
 		try {
-			existingUser = (await this.auth.getUserByProviderId(
-				"twitch",
-				twitchUserId
-			)) as GetUserType<A>;
+			existingUser = (await this.auth.getUserByProviderId("twitch", twitchUserId)) as LuciaUser<A>;
 		} catch {
 			// existingUser is null
 		}
+		const createUser = (async (userAttributes) => {
+			return await this.auth.createUser("twitch", twitchUserId, {
+				attributes: userAttributes as any
+			});
+		}) as CreateUser<A>;
 		return {
-			createUser: async (userAttributes?: GetCreateUserAttributesType<A>): Promise<GetUserType<A>> => {
-				return (await this.auth.createUser("twitch", twitchUserId, {
-					attributes: userAttributes
-				})) as any;
-			},
+			createUser,
 			existingUser,
 			providerUser: twitchUser,
 			accessToken


### PR DESCRIPTION
## Changes

### `@lucia-auth/oauth` 0.3.0

- [Breaking] Rename type `GetUserType` to `LuciaUser`; remove `GetCreateUserAttributesType`
- `userAttributes` params for `createUser()` is optional if `Lucia.UserAttributes` is empty
- Make `Buffer` dependency optional