### PR TITLE
Fix reference documentation

### DIFF
--- a/documentation/collection/integration/sveltekit/api-reference/server-api.md
+++ b/documentation/collection/integration/sveltekit/api-reference/server-api.md
@@ -71,7 +71,7 @@ const handleServerSession: (serverLoad?: ServerLoad) => ServerLoad;
 ```ts
 import { auth } from "$lib/server/lucia";
 import { handleServerSession } from "@lucia-auth/sveltekit";
-import type { LayoutServerLoadEvent } from "$./types";
+import type { LayoutServerLoadEvent } from "./$types";
 
 export const Load = handleServerSession(async (event: LayoutServerLoadEvent) => {
 	return {

--- a/documentation/collection/main/reference/configure/lucia-configurations.md
+++ b/documentation/collection/main/reference/configure/lucia-configurations.md
@@ -149,7 +149,7 @@ const generate: (s: string) => MaybePromise<string>;
 Validates a string against a hash generated using [`hash.generate()`](/reference/configure/lucia-configurations#generate-required).
 
 ```ts
-const generate: (s: string, hash: string) => MaybePromise<string>;
+const generate: (s: string, hash: string) => MaybePromise<boolean>;
 ```
 
 ##### Parameter
@@ -157,7 +157,7 @@ const generate: (s: string, hash: string) => MaybePromise<string>;
 | name | type     | description                         |
 | ---- | -------- | ----------------------------------- |
 | s    | `string` | the string to validate              |
-| hash | `string  | hash to validate the string against |
+| hash | `string` | hash to validate the string against |
 
 ##### Returns
 

--- a/documentation/collection/main/reference/configure/lucia-configurations.md
+++ b/documentation/collection/main/reference/configure/lucia-configurations.md
@@ -149,7 +149,7 @@ const generate: (s: string) => MaybePromise<string>;
 Validates a string against a hash generated using [`hash.generate()`](/reference/configure/lucia-configurations#generate-required).
 
 ```ts
-const generate: (s: string, hash: string) => MaybePromise<boolean>;
+const validate: (s: string, hash: string) => MaybePromise<boolean>;
 ```
 
 ##### Parameter


### PR DESCRIPTION
Fixed small reference documentation errors for `hash.validate` and `handleServerSession`. 