### PR TITLE
Extend `locals` type with `App.Locals` in SvelteKit

### DIFF
--- a/packages/sveltekit/CHANGELOG.md
+++ b/packages/sveltekit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.3
+
+- Extend type `locals` with `App.Locals` [#307](https://github.com/pilcrowOnPaper/lucia-auth/issues/307)
+
 ## 0.5.2
 
 - Update peer dependency

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lucia-auth/sveltekit",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"description": "SvelteKit integration for Lucia",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/sveltekit/src/ambient.d.ts
+++ b/packages/sveltekit/src/ambient.d.ts
@@ -9,3 +9,7 @@ declare namespace Lucia {
 		};
 	};
 }
+
+declare namespace App {
+	export type Locals = {}
+}

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -9,13 +9,14 @@ export type RequestEvent = {
 			{ session: Session; user: User } | { session: null; user: null }
 		>;
 		setSession: (session: Session | null) => void;
-	};
+	} & App.Locals;
 	url: URL;
 	cookies: {
 		get: (name: string) => string | undefined;
 		set: (name: string, value: string, options: any) => void;
 		delete: any;
 		serialize: any;
+		[k: string | number | symbol]: any;
 	};
 	fetch: any;
 	getClientAddress: any;


### PR DESCRIPTION
Fixes #307 

## Changes

### `@lucia-auth/sveltekit` 0.5.3

- Extend type `locals` with `App.Locals`