### PR TITLE
Fix quick start docs

### DIFF
--- a/documentation/collection/integration/astro/start-here/quick-start.md
+++ b/documentation/collection/integration/astro/start-here/quick-start.md
@@ -167,7 +167,7 @@ Create `pages/login.astro`. This route will handle sign ins using a form, which 
 
 The same page will also handle form submissions.
 
-We'll use `username` as the provider id and the username as the provider user id. This tells Lucia to find a user that was created using username/password auth method where the unique identifier is the username. Create a new session if the password is valid, and store the session id.
+We’ll use the key created in the previous section to reference the user and authenticate them by validating the password. As such, "username" will be the provider id and the username will be the provider user id for `validateKeyPassword()`, which will return the key's user if the password is valid. Create a new session if the password is valid.
 
 ```astro
 ---

--- a/documentation/collection/integration/nextjs/start-here/quick-start.md
+++ b/documentation/collection/integration/nextjs/start-here/quick-start.md
@@ -248,7 +248,7 @@ export default Index;
 
 Create pages/api/login.ts. This API route will handle sign-ins.
 
-We’ll use the key created in the previous section to reference the user and authenticate them by validating the password. As such, "username" will be the provider id and the username will be the provider user id. We can validate the password using validateRequestKey().
+We’ll use the key created in the previous section to reference the user and authenticate them by validating the password. As such, "username" will be the provider id and the username will be the provider user id for `validateKeyPassword()`, which will return the key's user if the password is valid. Create a new session if the password is valid.
 
 ```ts
 // pages/api/login.ts
@@ -264,7 +264,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 		return res.status(400).json({});
 	try {
 		const authRequest = new AuthRequest(auth, req, res);
-		const key = await auth.validateRequestKey("username", username, password);
+		const key = await auth.validateKeyPassword("username", username, password);
 		const session = await auth.createSession(key.userId);
 		authRequest.setSession(session); // set cookie
 		return res.redirect(302, "/"); // redirect to profile page

--- a/documentation/collection/integration/sveltekit/start-here/quick-start.md
+++ b/documentation/collection/integration/sveltekit/start-here/quick-start.md
@@ -156,7 +156,7 @@ This form will also have an input field for username and password.
 
 ### Authenticate users
 
-We'll use the key created in the previous section to reference the user and authenticate them by validating the password. As such, `"username"` will be the provider id and the username will be the provider user id. We can validate the password using `validateRequestKey()`.
+We’ll use the key created in the previous section to reference the user and authenticate them by validating the password. As such, "username" will be the provider id and the username will be the provider user id for `validateKeyPassword()`, which will return the key's user if the password is valid. Create a new session if the password is valid.
 
 ```ts
 // routes/login/+page.server.ts
@@ -179,7 +179,7 @@ export const actions: Actions = {
 		if (typeof username !== "string" || typeof password !== "string")
 			return fail(400);
 		try {
-			const key = await auth.validateRequestKey("username", username, password);
+			const key = await auth.validateKeyPassword("username", username, password);
 			const session = await auth.createSession(key.userId);
 			locals.setSession(session);
 		} catch {


### PR DESCRIPTION
Fix typo (`validateRequestKey()`) and make the quick start docs consistent across framework integrations.